### PR TITLE
Added scripts for end-to-end gain reffile creation

### DIFF
--- a/nircam_calib/reffile_creation/pipeline/gain/example_run_gain_creation.py
+++ b/nircam_calib/reffile_creation/pipeline/gain/example_run_gain_creation.py
@@ -1,0 +1,42 @@
+#! /usr/bin/env python
+
+'''
+Test the gain creation scripts from beginning to end
+(from a pile of flats to a final CRDS reffile)
+'''
+
+from glob import glob
+from nircam_calib.reffile_creation.pipeline.gain import gain
+from nircam_calib.reffile_creation.pipeline.gain import final_gain_map
+
+files = glob('NRCN815B-LIN*saturation.fits')
+files.sort()
+print("Creating gain reference file from: {}".format(files))
+
+# Create individual gain files
+for i in range(0,len(files),2):
+    g = gain.Gainimclass()
+    g.flatfile1 = files[i]
+    g.flatfile2 = files[i+1]
+    g.boxsize = 128
+    g.gmax = 10
+    g.gainim(files[i],files[i+1])
+
+# Calculate the mean and make a reffile
+indfiles = glob('*dsubij.fits')
+gref = final_gain_map.Map()
+gref.gainlist = indfiles
+gref.author = 'Bryan Hilbert'
+gref.descrip = 'This is a test reference file'
+gref.pedigree = 'GROUND then until now'
+gref.useafter = '2014-01-01T00:00:00.0'
+gref.save_output = True
+gref.outfile = 'NIRCam_TESTTEST_B3_CV3_128x128_gain.fits'
+gref.history = ("This is a long history entry "
+                "talking about how much blood, "
+                "sweat, and tears went into making "
+                "this reference file. But what used "
+                "to be manual is now automated, so "
+                "let's see how it comes out.")
+gref.create_map()
+

--- a/nircam_calib/reffile_creation/pipeline/gain/final_gain_map.py
+++ b/nircam_calib/reffile_creation/pipeline/gain/final_gain_map.py
@@ -1,0 +1,171 @@
+#! /usr/bin/env python
+
+'''
+Given a series of individual gain maps, create a mean gain
+map and error array
+
+If the indiviual gain files were created using gain.py, then
+this script will check the headers of those files
+and create a list of flats and darks used to create the gain.
+These lists will be appended to the history string.
+
+'''
+
+import sys
+import copy
+import numpy as np
+from astropy.stats import sigma_clip
+from astropy.io import fits
+from . import gain_reffile as gainref
+
+class Map():
+    def __init__(self):
+        self.gainlist = []
+        self.author = ''
+        self.descrip = ''
+        self.pedigree = ''
+        self.useafter = ''
+        self.history = ''
+        self.save_output = True
+        self.outfile = ''
+        self.outdir = './'
+        
+        
+    def check_headers(self,hdrlist):
+        '''Make sure inputs have consistent header info'''
+        dets = []
+        for i,h in enumerate(hdrlist):
+            det = h['DETECTOR']
+            if i == 0:
+                compdet = copy.deepcopy(det)
+            if det != compdet:
+                print(("WARNING: inconsistent detector values"
+                       "in input file headers. Quitting."))
+                sys.exit()
+        
+
+    def create_map(self):
+        '''Main function'''
+
+        # Read in individual input files
+        if isinstance(self.gainlist[0],str):
+            hdrs = []
+            flatfiles = []
+            darkfiles = []
+            for i,file in enumerate(self.gainlist):
+                im,err,hdr0 = self.read_data(file)
+                if i == 0:
+                    gainims = copy.deepcopy(im)
+                    gainerrs = copy.deepcopy(err)
+                else:
+                    if im.shape[1:] != gainims.shape[1:]:
+                        print(("WARNING: inconsistent array sizes "
+                               "in input files. Quitting."))
+                        sys.exit
+                    gainims = np.vstack([gainims,im])
+                    gainerrs = np.vstack([gainerrs,err])
+                hdrs.append(hdr0)
+
+                # Get a list of files used to create the
+                # mean gain map
+                flats = self.get_ffiles(hdr0)
+                flatfiles += flats
+                darks = self.get_dfiles(hdr0)
+                if darks[0] not in [None,'']:
+                    darkfiles += darks
+
+        # If the lists of flat and dark files have entries
+        # in them, add them to the HISTORY
+        if len(flatfiles) > 0:
+            newtext = ("Flatfield files used to create this "
+                       "gain map:  ")
+            for f in flatfiles:
+                newtext += "{}, ".format(f)
+            self.history += newtext
+        if len(darkfiles) > 0:
+            newtext = ("Dark current files used to create this "
+                       "gain map: ")
+            for f in darkfiles:
+                newtext += "{}, ".format(f)
+            self.history += newtext
+        
+        # Check headers for consistency
+        self.check_headers(hdrs)
+
+        # Calculate the sigma-clipped mean through the stack
+        # astropy.stats.SigmaClip gives confusing results
+        # so let's fall back to scipy's version
+        yd,xd = gainims.shape[1:]
+        self.gain = np.zeros((yd,xd))
+        self.gainerr = np.zeros((yd,xd))
+
+        p = sigma_clip(gainims,sigma=3,axis=0)
+        for x in range(xd):
+            for y in range(yd):
+                ppix = p[:,y,x]
+                mn = np.mean(ppix.data[~ppix.mask])
+                self.gain[y,x] = mn
+                gs = gainims[:,y,x]
+                errs = gainerrs[:,y,x]
+                perr = np.sqrt(np.sum((gs[~ppix.mask]*errs[~ppix.mask])**2)
+                               / np.sum(~ppix.mask)**2)
+                self.gainerr[y,x] = perr
+                
+        if self.save_output:
+            # Save in CRDS format
+            det = hdrs[0]['DETECTOR']
+            if '5' in det:
+                det = det.replace('5','LONG')
+
+            self.get_axes_values(det)
+            gfile = gainref.GainFile()
+            gfile.detector = det
+            gfile.author = self.author
+            gfile.descrip = self.descrip
+            gfile.useafter = self.useafter
+            gfile.pedigree = self.pedigree
+            gfile.history = self.history
+            gfile.outdir = self.outdir
+            gfile.outfile = self.outfile
+            gfile.fastaxis = self.fastaxis
+            gfile.slowaxis = self.slowaxis
+            gfile.save(self.gain,self.gainerr)
+            
+
+    def get_axes_values(self,detector):
+        '''Retrieve the appropriate fastaxis and slowaxis
+        keywords for the given detector'''
+        if detector in ['NRCA2','NRCA4','NRCB1','NRCB3','NRCBLONG']:
+            self.fastaxis = 1
+            self.slowaxis = -2
+        elif detector in ['NRCA1','NRCA3','NRCB2','NRCB4','NRCALONG']:
+            self.fastaxis = -1
+            self.slowaxis = 2
+
+            
+    def get_dfiles(self,hdu):
+        '''Return the dark current files used to
+        create an individual gain map'''
+        d1 = hdu['DARKFIL1']
+        d2 = hdu['DARKFIL2']
+        return [d1,d2]
+
+
+    def get_ffiles(self,hdu):
+        '''Return the flat field files used to
+        create an individual gain map'''
+        f1 = hdu['FLATFIL1']
+        f2 = hdu['FLATFIL2']
+        return [f1,f2]
+
+    
+    def read_data(self,infile):
+        '''Read in an individual gain file, return
+        gain map, error map, and header'''
+        with fits.open(infile) as h:
+            im = h['gain'].data
+            err = h['gain_err'].data
+            hdr0 = h[0].header
+            im = np.expand_dims(im,0)
+            err = np.expand_dims(err,0)
+        return im, err, hdr0

--- a/nircam_calib/reffile_creation/pipeline/gain/gain.py
+++ b/nircam_calib/reffile_creation/pipeline/gain/gain.py
@@ -154,6 +154,7 @@ class Gainimclass:
         gainfilename = self.outfilebasename+'.gain.%s.fits' % imtype
         phdu = fits.PrimaryHDU(data=None)
         hdu_gain = fits.ImageHDU(gainim,name='gain')
+        phdu = self.set_header_info(phdu)
         hdu_gain_err = fits.ImageHDU(gainim_err,name='gain_err')
         hdulist = fits.HDUList([phdu,hdu_gain,hdu_gain_err])
         #print('Saving ',gainfilename)
@@ -163,6 +164,21 @@ class Gainimclass:
         del gainim, gainim_err, hdulist, hdu_gain, hdu_gain_err
 
 
+    def set_header_info(self,hdu):
+        '''
+        Populate necessary header information in the output file
+        '''
+        hdu.header['FILETYPE'] = 'GAIN'
+        hdu.header['DETECTOR'] = self.hdr1['DETECTOR']
+        hdu.header['INSTRUME'] = 'NIRCAM'
+        hdu.header['TELESCOP'] = 'JWST'
+        hdu.header['FLATFIL1'] = self.flatfile1
+        hdu.header['FLATFIL2'] = self.flatfile2
+        hdu.header['DARKFIL1'] = self.darks[0]
+        hdu.header['DARKFIL2'] = self.darks[1]
+        return hdu
+
+               
     def correct_stdev2_with_rdnoiseterms(self,boxmap,box_location,tsubik,tsubg0,tdsub1,
                                          tdsub2,tdsubij,Smean_max=None,Pmax=20.0,Nmin=3):
 
@@ -1194,7 +1210,7 @@ class Gainimclass:
         darks4readnoiselist = self.darks
         
         # Get the proper darks
-        if self.darks is not None:
+        if self.darks[0] is not None:
             darkfilelist = [os.path.abspath(self.darks[0]),os.path.abspath(self.darks[1])]
             print('Using the following dark frames:',darkfilelist)
         elif self.autodark4readnoise:
@@ -1210,7 +1226,7 @@ class Gainimclass:
         else:
             darkfilelist = None
         
-        if darks4readnoiselist is not None:
+        if darks4readnoiselist[0] is not None:
             self.readnoisemethod='doublediff'
         else:
             self.readnoisemethod='dsub12'
@@ -1267,7 +1283,7 @@ class Gainimclass:
         self.bpmmask = self.mkbpmmask(self.data1,self.hdr1,self.boxmap,self.box_centers)
 
         # get the readnoise from the dark frames if wanted...
-        if darks4readnoiselist is not None:
+        if darks4readnoiselist[0] is not None:
             #self.darks4readnoise(darks4readnoiselist,(xmin,xmax,boxsize),
             #                     (ymin,ymax,boxsize),mask=self.bpmmask,
             #                     gmax=self.gmax4dark,skiprefpixcorr=skiprefpixcorr,
@@ -1476,7 +1492,7 @@ class Gainimclass:
         
 if __name__=='__main__':
 
-    usagestring='USAGE: calcgainim.py flatfilename1 flatfilename2'
+    usagestring='USAGE: gain.py flatfilename1 flatfilename2'
 
     g = gainimclass()
     parser = g.add_options(usage = usagestring)


### PR DESCRIPTION
Added final_gain_map.py, which takes a list of gain files created from pairs of ramps, averages them together, and calls gain_reffile.py to save the result in a CRDS-formatted reference file that is ready for testing and delivery. 

Also added example_run_gain_creation.py to show an example of how to go from a list of individual flat field and dark files to a final gain reference file.

Made a small update to gain.py such that when it creates a gain map from a pair of flats and optionally darks, it saves the names of these flats and darks in the header of the gain map. Then when multiple gain files are averaged to make a final gain map, these flat and dark filenames are extracted and placed into the history section of the final reference file.