### PR TITLE
Made location of metadata in gain output more explicit

### DIFF
--- a/nircam_calib/reffile_creation/pipeline/gain/gain.py
+++ b/nircam_calib/reffile_creation/pipeline/gain/gain.py
@@ -168,14 +168,14 @@ class Gainimclass:
         '''
         Populate necessary header information in the output file
         '''
-        hdu.header['FILETYPE'] = 'GAIN'
-        hdu.header['DETECTOR'] = self.hdr1['DETECTOR']
-        hdu.header['INSTRUME'] = 'NIRCAM'
-        hdu.header['TELESCOP'] = 'JWST'
-        hdu.header['FLATFIL1'] = self.flatfile1
-        hdu.header['FLATFIL2'] = self.flatfile2
-        hdu.header['DARKFIL1'] = self.darks[0]
-        hdu.header['DARKFIL2'] = self.darks[1]
+        hdu[0].header['FILETYPE'] = 'GAIN'
+        hdu[0].header['DETECTOR'] = self.hdr1['DETECTOR']
+        hdu[0].header['INSTRUME'] = 'NIRCAM'
+        hdu[0].header['TELESCOP'] = 'JWST'
+        hdu[0].header['FLATFIL1'] = self.flatfile1
+        hdu[0].header['FLATFIL2'] = self.flatfile2
+        hdu[0].header['DARKFIL1'] = self.darks[0]
+        hdu[0].header['DARKFIL2'] = self.darks[1]
         return hdu
 
                


### PR DESCRIPTION
Data being placed into the header of the output individual gain file is placed in extension 0. Previously the extension number was not specified and astropy must have defaulted to 
extension 0. Now extension 0 is explicitly mentioned, for clarity.