### PR TITLE
Add notebook for running CRDS completeness check

### DIFF
--- a/nircam_calib/reffile_creation/crds_completeness_check/nircam_crds_completeness_check.ipynb
+++ b/nircam_calib/reffile_creation/crds_completeness_check/nircam_crds_completeness_check.ipynb
@@ -1,0 +1,3921 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# NIRCam CRDS Completeness Check"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook captures all supported NIRCam configurations (exp_type/detector/subarray/filter/pupil/etc) and queries CRDS using each configuration, in order to be sure that appropriate reference files exist."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Page listing exp_types and which pipelines they are to be processed through: \n",
+    "https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/main.html#pipelines-vs-exposure-type\n",
+    "\n",
+    "Page listing observing templates and corresponding exposure types:\n",
+    "https://innerspace.stsci.edu/pages/viewpage.action?spaceKey=JSSE&title=Templates+-+modes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "MIMF are all FULL and tagged as NRC_IMAGE\n",
+    "What about coronagraphic TA? I skipped over all of these as they will only be processed through calwebb_detector1 and the dark step will be skipped for TA data. All other detector1 reference files have the subarray extracted from the full frame.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Table of Contents"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Table of Contents:*,\n",
+    "* [Lists of Reference Files to Search For](#reffile_lists)\n",
+    "* [Lists of Allowed Parameter Combinations, by Exposure Type](#allowed_parameters)\n",
+    "    * [Imaging Mode Parameters](#imaging_params)\n",
+    "    * [WFSS Mode Parameters](#wfss_params)\n",
+    "    * [Imaging Time Series Parameters](#tsimage_params)\n",
+    "    * [Grism Time Series Parameters](#tsgrism_params)\n",
+    "    * [Coronagraphy Parameters](#coron_params)\n",
+    "    * [Engineering Imaging Parameters](#engimg_params)\n",
+    "    * [Dark Parameters](#dark_params)\n",
+    "    * [Target Acquisition Parameters](#ta_params)\n",
+    "    * [Target Acquisition Confirmation Parameters](#taconfirm_params)\n",
+    "    * [Focus Parameters](#focus_params)\n",
+    "    * [Flat Parameters](#flat_params)\n",
+    "    * [LED Parameters](#led_params)\n",
+    "    * [Grism Parameters](#grism_params)\n",
+    "* [Function Definitions](#function_definitions)\n",
+    "* [Create All Possible Combinations of Paramters](#create_combinations)\n",
+    "    * [Imaging Mode](#imaging_combos)\n",
+    "    * [WFSS Mode](#wfss_combos)\n",
+    "    * [Imaging Time Series](#tsimage_combos)\n",
+    "    * [Grism Time Series](#tsgrism_combos)\n",
+    "    * [Coronagraphy](#coron_combos)\n",
+    "    * [Engineering Imaging](#engimg_combos)\n",
+    "    * [Dark](#dark_combos)\n",
+    "    * [Target Acquisition](#ta_combos)\n",
+    "    * [Target Acquisition Confirmation](#taconfirm_combos)\n",
+    "    * [Focus](#focus_combos)\n",
+    "    * [Flat](#flat_combos)\n",
+    "    * [LED](#led_combos)\n",
+    "    * [Grism](#grism_combos)\n",
+    "* [Run CRDS Queries](#run_queries)\n",
+    "    * [Imaging Mode Queries](#imaging_queries)\n",
+    "    * [WFSS Mode Queries](#wfss_queries)\n",
+    "    * [Imaging Time Series Queries](#tsimage_queries)\n",
+    "    * [Grism Time Series Queries](#tsgrism_queries)\n",
+    "    * [Coronagraphy Queries](#coron_queries)\n",
+    "    * [Engineering Imaging Queries](#engimg_queries)\n",
+    "    * [Dark Queries](#dark_queries)\n",
+    "    * [Target Acquisition Queries](#ta_queries)\n",
+    "    * [Target Acquisition Confirmation Queries](#taconfirm_queries)\n",
+    "    * [Focus Queries](#focus_queries)\n",
+    "    * [Flat Queries](#flat_queries)\n",
+    "    * [LED Queries](#led_queries)\n",
+    "    * [Grism Queries](#grism_queries)\n",
+    "* [Final Summary](#final_summary)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "make sure you have the right exp_types for engineering imaging. It can be several values. right now I think I'm using only nrc_image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import datetime\n",
+    "\n",
+    "import crds\n",
+    "from crds import CrdsLookupError"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "<a id='reffile_lists'></a>\n",
+    "## Lists of reference files we are looking for"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What about parameter reference files? I guess these aren't necessary for the pipeline to run\n",
+    "# but it could still be useful to know which we have and which we don't\n",
+    "\n",
+    "# Looks like we can't just search for all reference files in one go. PSFMASK shows up as\n",
+    "# not found in cases where CORONMSK is not present, as well as in cases where CORONMSK\n",
+    "# is 'N/A' or some other random string.\n",
+    "\n",
+    "\n",
+    "level1b_reffiles = ['mask', 'ipc', 'saturation', 'superbias',\n",
+    "                    'linearity', 'dark', 'gain', 'readnoise',\n",
+    "                   'persat', 'trapdensity', 'trappars']\n",
+    "\n",
+    "level2a_imaging_reffiles = ['distortion', 'area', 'flat', 'photom',\n",
+    "                           ]\n",
+    "level2a_grism_reffiles = ['distortion', 'area', 'flat', 'photom',\n",
+    "                          'specwcs', 'wavelengthrange']\n",
+    "\n",
+    "level3_imaging_reffiles = ['distortion']\n",
+    "level3_wfss_reffiles = ['wfssbkg', 'apcorr', 'abvegaoffset']\n",
+    "level3_coron_reffiles = ['psfmask']\n",
+    "level3_tso_reffiles = ['tsophot']\n",
+    "\n",
+    "all_reffiles = ['mask', 'ipc', 'saturation', 'superbias',\n",
+    "                'linearity', 'dark', 'gain', 'readnoise',\n",
+    "                'persat', 'trapdensity', 'trappars',\n",
+    "                'distortion', 'area', 'flat', 'photom',\n",
+    "                'specwcs', 'wavelengthrange',\n",
+    "                'wfssbkg', 'apcorr', 'abvegaoffset',\n",
+    "                'psfmask', 'tsophot']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "<a id='allowed_parameters'></a>\n",
+    "## Lists of allowed parameters, by exposure type"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='imaging_params'></a>\n",
+    "### Imaging"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NRC_IMAGE data are run through calwebb_detector1, calwebb_image2, and calwebb_image3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_image_exptype = 'NRC_IMAGE'\n",
+    "nrc_image_sw_dets = ['NRCA1', 'NRCA2', 'NRCA3', 'NRCA4', 'NRCB1', 'NRCB2', 'NRCB3', 'NRCB4']\n",
+    "nrc_image_sw_subarrays = ['FULL', 'SUB640', 'SUB320', 'SUB160']\n",
+    "nrc_image_sw_filterpupil = ['F070W/CLEAR', 'F090W/CLEAR', 'F115W/CLEAR', 'F150W/CLEAR', 'F150W2/CLEAR',\n",
+    "                            'F200W/CLEAR', 'F140M/CLEAR', 'F182M/CLEAR', 'F210M/CLEAR', 'F187N/CLEAR',\n",
+    "                            'F212N/CLEAR', 'WLP4/CLEAR', 'F150W2/F164N']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_image_lw_dets = ['NRCALONG', 'NRCBLONG']\n",
+    "nrc_image_lw_subarrays = nrc_image_sw_subarrays\n",
+    "nrc_image_lw_filterpupil = ['F277W/CLEAR', 'F322W2/CLEAR', 'F356W/CLEAR', 'F444W/CLEAR',\n",
+    "                            'F250M/CLEAR', 'F300M/CLEAR',  'F335M/CLEAR', 'F360M/CLEAR',\n",
+    "                            'F410M/CLEAR', 'F430M/CLEAR', 'F460M/CLEAR',  'F480M/CLEAR',\n",
+    "                            'F322W2/F323N', 'F444W/F405N', 'F444W/F466N',\n",
+    "                            'F444W/F470N']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_image_sw_p_dets = ['NRCB1']\n",
+    "nrc_image_sw_p_subarrays = ['SUB400P', 'SUB160P', 'SUB64P']\n",
+    "nrc_image_sw_p_filterpupil = nrc_image_sw_filterpupil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_image_lw_p_dets = ['NRCBLONG']\n",
+    "nrc_image_lw_p_subarrays = ['SUB400P', 'SUB160P', 'SUB64P']\n",
+    "nrc_image_lw_p_filterpupil = nrc_image_lw_filterpupil"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='wfss_params'></a>\n",
+    "### WFSS"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "WFSS data are run through calwebb_detector1, calwebb_spec2, calwebb_spec3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_wfss_exptype = 'NRC_WFSS'\n",
+    "nrc_wfss_detectors = ['NRCALONG', 'NRCBLONG']\n",
+    "nrc_wfss_subarrays = ['FULL']\n",
+    "nrc_wfss_lw_filterpupil = ['F277W/GRISMR', 'F322W2/GRISMR', 'F356W/GRISMR', 'F444W/GRISMR',\n",
+    "                           'F250M/GRISMR', 'F300M/GRISMR', 'F335M/GRISMR', 'F360M/GRISMR',\n",
+    "                           'F410M/GRISMR', 'F430M/GRISMR', 'F460M/GRISMR', 'F480M/GRISMR',\n",
+    "                           'F277W/GRISMC', 'F322W2/GRISMC', 'F356W/GRISMC', 'F444W/GRISMC',\n",
+    "                           'F250M/GRISMC', 'F300M/GRISMC', 'F335M/GRISMC', 'F360M/GRISMC',\n",
+    "                           'F410M/GRISMC', 'F430M/GRISMC', 'F460M/GRISMC', 'F480M/GRISMC']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='tsimage_params'></a>\n",
+    "### Imaging Time Series"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Imaging Time Series data are run through calwebb_detector1, calwebb_image2, calwebb_tso3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_tsimg_exptype = 'NRC_TSIMAGE'\n",
+    "nrc_tsimg_sw_detectors = ['NRCB1']\n",
+    "nrc_tsimg_sw_subarrays = ['FULL', 'SUB400P', 'SUB160P', 'SUB64P']\n",
+    "nrc_tsimg_sw_filterpupil = ['F070W/CLEAR', 'F090W/CLEAR', 'F115W/CLEAR', 'F150W/CLEAR',\n",
+    "                            'F150W2/CLEAR', 'F200W/CLEAR', 'F140M/CLEAR',  'F182M/CLEAR',\n",
+    "                            'F210M/CLEAR', 'F187N/CLEAR', 'F212N/CLEAR', 'WLP4/CLEAR',\n",
+    "                            'F150W/WLP8', 'F200W/WLP8', 'F140M/WLP8', 'F182M/WLP8',\n",
+    "                            'F210M/WLP8', 'F187N/WLP8', 'F212N/WLP8']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_tsimg_lw_detectors = ['NRCBLONG']\n",
+    "nrc_tsimg_lw_subarrays = ['FULL', 'SUB400P', 'SUB160P', 'SUB64P']\n",
+    "nrc_tsimg_lw_filterpupil = ['F277W/CLEAR', 'F322W2/CLEAR', 'F356W/CLEAR', 'F444W/CLEAR',\n",
+    "                            'F250M/CLEAR', 'F300M/CLEAR',  'F335M/CLEAR', 'F360M/CLEAR',\n",
+    "                            'F410M/CLEAR', 'F430M/CLEAR', 'F460M/CLEAR', 'F480M/CLEAR',\n",
+    "                            'F322W2/F323N', 'F322W2/F405N', 'F410M/F405N', 'F444W/F466N',\n",
+    "                            'F444W/F470N']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These combinations are for data that are collected contemporaneously with grism time\n",
+    "series data in the LW channel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_tsgrism_sw_detectors = ['NRCA1', 'NRCA3']\n",
+    "nrc_tsgrism_sw_subarrays = ['FULL', 'SUBGRISM256', 'SUBGRISM128', 'SUBGRISM64']\n",
+    "nrc_tsgrism_sw_filterpupils = ['F070W/WLP8', 'F140M/WLP8', 'F182M/WLP8', 'F210M/WLP8',\n",
+    "                               'F187N/WLP8', 'F212N/WLP8', 'WLP4/CLEAR']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='tsgrism_params'></a>\n",
+    "### Grism Time Series"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Grism Time Series data are run through calwebb_detector1, calwebb_image2, calwebb_tso3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_tsgrism_exptype = 'NRC_TSGRISM'\n",
+    "nrc_tsgrism_lw_detectors = ['NRCALONG']\n",
+    "nrc_tsgrism_lw_subarrays = ['FULL', 'SUBGRISM256', 'SUBGRISM128', 'SUBGRISM64']\n",
+    "nrc_tsgrism_lw_filterpupil = ['F277W/GRISMR', 'F322W2/GRISMR', 'F356W/GRISMR', 'F444W/GRISMR']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='coron_params'></a>\n",
+    "### Coronagraphy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Coronagraphy data are run through calwebb_detector1, calwebb_image2, calwebb_coron3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_exptype = 'NRC_CORON'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_sw_round_detectors = ['NRCA2']\n",
+    "nrc_coron_sw_round_mask = ['MASK210R']\n",
+    "nrc_coron_sw_subarrays = ['FULL', 'SUB640A210R']\n",
+    "nrc_coron_sw_round_filterpupils = ['F200W/MASKRND', 'F182M/MASKRND', 'F210M/MASKRND',\n",
+    "                                   'F187N/MASKRND', 'F212N/MASKRND']\n",
+    "\n",
+    "nrc_coron_sw_bar_detectors = ['NRCA4']\n",
+    "nrc_coron_sw_bar_mask = ['FULL', 'MASKSWB']\n",
+    "nrc_coron_sw_bar_subarrays = ['FULL', 'SUB640ASWB']\n",
+    "nrc_coron_sw_bar_filterpupils = ['F200W/MASKBAR', 'F182M/MASKBAR', 'F210M/MASKBAR',\n",
+    "                                   'F187N/MASKBAR', 'F212N/MASKBAR']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_lw_detectors = ['NRCALONG']\n",
+    "nrc_coron_lw_round_335_mask = ['MASK335R']\n",
+    "nrc_coron_lw_round_335_subarrays = ['FULL', 'SUB320A335R']\n",
+    "nrc_coron_lw_round_335_filterpupils = ['F322W2/MASKRND', 'F356W/MASKRND', 'F250M/MASKRND',\n",
+    "                                   'F300M/MASKRND', 'F335M/MASKRND', 'F360M/MASKRND',\n",
+    "                                   'F410M/MASKRND']\n",
+    "\n",
+    "nrc_coron_lw_round_430_mask = ['MASK430R']\n",
+    "nrc_coron_lw_round_430_subarrays = ['FULL', 'SUB320A430R']\n",
+    "nrc_coron_lw_round_430_filterpupils = ['F322W2/MASKRND', 'F356W/MASKRND', 'F444W/MASKRND',\n",
+    "                                       'F250M/MASKRND', 'F300M/MASKRND', 'F335M/MASKRND',\n",
+    "                                       'F360M/MASKRND', 'F410M/MASKRND', 'F430M/MASKRND',\n",
+    "                                       'F460M/MASKRND']\n",
+    "\n",
+    "nrc_coron_lw_bar_mask = ['MASKLWB']\n",
+    "nrc_coron_lw_bar_subarrays = ['FULL', 'SUB320ALWB']\n",
+    "nrc_coron_lw_bar_filterpupils = ['F277W/MASKBAR', 'F356W/MASKBAR', 'F444W/MASKBAR',\n",
+    "                                 'F250M/MASKBAR', 'F300M/MASKBAR', 'F335M/MASKBAR',\n",
+    "                                 'F360M/MASKBAR', 'F410M/MASKBAR', 'F430M/MASKBAR',\n",
+    "                                 'F460M/MASKBAR', 'F480M/MASKBAR']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='engimg_params'></a>\n",
+    "### Engineering Imaging"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This mode allows just about any filter/pupil/subarray combination. Latest talk is for having engineering imaging data stop after calwebb_detector1, which means no filter-dependent reference files. This makes the check much simpler, as we can just include a single filter/pupil pair in the set of parameters. No need to worry about checking all possible combinations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_engimg_sw_detectors = ['NRCB1']\n",
+    "nrc_engimg_sw_subarrays = ['FULL', 'SUB400P', 'SUB160P', 'SUB64P']\n",
+    "nrc_engimg_sw_filterpupils = ['F200W/CLEAR']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_engimg_lw_detectors = ['NRCBLONG']\n",
+    "nrc_engimg_lw_subarrays = ['FULL', 'SUB400P', 'SUB160P', 'SUB64P']\n",
+    "nrc_engimg_lw_filterpupils = ['F444W/CLEAR']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_engimg_sw_round_detectors = ['NRCB1']\n",
+    "nrc_engimg_sw_round_mask = ['MASK210R']\n",
+    "nrc_engimg_sw_round_subarrays = ['FULL', 'SUB640B210R']\n",
+    "nrc_engimg_sw_round_filterpupils = ['F200W/MASKRND', 'F182M/MASKRND', 'F210M/MASKRND',\n",
+    "                                   'F187N/MASKRND', 'F212N/MASKRND']\n",
+    "\n",
+    "nrc_engimg_sw_bar_detectors = ['NRCB3']\n",
+    "nrc_engimg_sw_bar_mask = ['FULL', 'MASKSWB']\n",
+    "nrc_engimg_sw_bar_subarrays = ['FULL', 'SUB640BSWB']\n",
+    "nrc_engimg_sw_bar_filterpupils = ['F200W/MASKBAR', 'F182M/MASKBAR', 'F210M/MASKBAR',\n",
+    "                                   'F187N/MASKBAR', 'F212N/MASKBAR']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_engimg_lw_detectors = ['NRCBLONG']\n",
+    "nrc_engimg_lw_round_335_mask = ['MASK335R']\n",
+    "nrc_engimg_lw_round_335_subarrays = ['FULL', 'SUB320B335R']\n",
+    "nrc_engimg_lw_round_335_filterpupils = ['F322W2/MASKRND', 'F356W/MASKRND', 'F250M/MASKRND',\n",
+    "                                   'F300M/MASKRND', 'F335M/MASKRND', 'F360M/MASKRND',\n",
+    "                                   'F410M/MASKRND']\n",
+    "\n",
+    "nrc_engimg_lw_round_430_mask = ['MASK430R']\n",
+    "nrc_engimg_lw_round_430_subarrays = ['FULL', 'SUB320B430R']\n",
+    "nrc_engimg_lw_round_430_filterpupils = ['F322W2/MASKRND', 'F356W/MASKRND', 'F444W/MASKRND',\n",
+    "                                       'F250M/MASKRND', 'F300M/MASKRND', 'F335M/MASKRND',\n",
+    "                                       'F360M/MASKRND', 'F410M/MASKRND', 'F430M/MASKRND',\n",
+    "                                       'F460M/MASKRND']\n",
+    "\n",
+    "nrc_engimg_lw_bar_mask = ['MASKLWB']\n",
+    "nrc_engimg_lw_bar_subarrays = ['FULL', 'SUB320BLWB']\n",
+    "nrc_engimg_lw_bar_filterpupils = ['F277W/MASKBAR', 'F356W/MASKBAR', 'F444W/MASKBAR',\n",
+    "                                 'F250M/MASKBAR', 'F300M/MASKBAR', 'F335M/MASKBAR',\n",
+    "                                 'F360M/MASKBAR', 'F410M/MASKBAR', 'F430M/MASKBAR',\n",
+    "                                 'F460M/MASKBAR', 'F480M/MASKBAR']\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_engimg_fp_a3_detectors = ['A3']\n",
+    "nrc_engimg_fp_a3_subarrays = ['SUB64FP1A', 'SUB64FP1A']\n",
+    "\n",
+    "nrc_engimg_fp_b4_detectors = ['B4']\n",
+    "nrc_engimg_fp_b4_subarrays = ['SUB64FP1B', 'SUB8FP1B']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_engimg_dhs_a_detectors = ['NRCA3']\n",
+    "nrc_engimg_dhs_a_subarrays = ['SUB96DHSPILA']\n",
+    "nrc_engimg_dhs_filterpupil = ['F115W/GDHS0', 'F150W/GDHS0', 'F150W2/GDHS0',\n",
+    "                              'F200W/GDHS0', 'F140M/GDHS0', 'F182M/GDHS0', 'F210M/GDHS0', 'F187N/GDHS0',\n",
+    "                              'F212N/GDHS0', 'F115W/GDHS60', 'F150W/GDHS60', 'F150W2/GDHS60',\n",
+    "                              'F200W/GDHS60', 'F140M/GDHS60', 'F182M/GDHS60', 'F210M/GDHS60', 'F187N/GDHS60',\n",
+    "                              'F212N/GDHS60']\n",
+    "\n",
+    "nrc_engimg_dhs_b_detectors = ['NRCB4']\n",
+    "nrc_engimg_dhs_b_subarrays = ['SUB96DHSPILB']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='dark_params'></a>\n",
+    "### Darks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Dark data are run through calwebb_dark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_dark_exptype = 'NRC_DARK'\n",
+    "nrc_dark_sw_dets = ['NRCA1', 'NRCA2', 'NRCA3', 'NRCA4', 'NRCB1', 'NRCB2', 'NRCB3', 'NRCB4']\n",
+    "nrc_dark_sw_subarrays = ['FULL', 'SUB640', 'SUB320', 'SUB160']\n",
+    "\n",
+    "# Only need one combination here since detector1 reffiles are not\n",
+    "# filter dependent\n",
+    "nrc_dark_sw_pupils = ['F090W/FLAT']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_dark_lw_dets = ['NRCALONG', 'NRCBLONG']\n",
+    "nrc_dark_lw_subarrays = ['FULL', 'SUB640', 'SUB320', 'SUB160']\n",
+    "\n",
+    "# Only need one combination here since detector1 reffiles are not\n",
+    "# filter dependent\n",
+    "nrc_dark_lw_pupils = ['F444W/FLAT']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_dark_sw_p_dets = ['NRCB1']\n",
+    "nrc_dark_p_subarrays = ['SUB400P', 'SUB160P', 'SUB64P']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_dark_lw_p_dets = ['NRCBLONG']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Include grism time series subarrays\n",
+    "# (imaging time series subarrays are included within imaging mode above)\n",
+    "nrc_dark_grismts_sw_dets = nrc_tsgrism_sw_detectors\n",
+    "nrc_dark_grismts_sw_subarrays = nrc_tsgrism_sw_subarrays\n",
+    "\n",
+    "nrc_dark_grismts_lw_dets = nrc_tsgrism_lw_detectors\n",
+    "nrc_dark_grismts_lw_subarrays = nrc_tsgrism_lw_subarrays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Coronagraphy subarrays...are not covered? is sub640 the same as sub640 in imaging mode?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TA observations will have dark current subtraction skipped, so we\n",
+    "# need to omit the dark search for them"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# subarrays shouldn't matter much here since we are doing only calwebb_detector1\n",
+    "# reffiles. Of those, only the dark is not extracted from the full frame, and here, for nrc_dark\n",
+    "# data, we will not be doing dark subtraction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='ta_params'></a>\n",
+    "### Target Acquisition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Target Acquisition data are run through calwebb_detector1 and calwebb_image2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_ta_exptype = 'NRC_TACQ'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Coronagraphy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_ta_subarrays = ['SUB128', 'SUB64']\n",
+    "\n",
+    "nrc_coron_ta_round_detectors = ['NRCA2']\n",
+    "nrc_coron_ta_round_mask = ['MASK210R']\n",
+    "nrc_coron_ta_sw_round_filterpupils = ['F210M/MASKRND']\n",
+    "\n",
+    "nrc_coron_ta_bar_detectors = ['NRCA4']\n",
+    "nrc_coron_ta_bar_mask = ['MASKSWB']\n",
+    "nrc_coron_ta_sw_bar_filterpupils = ['F210M/MASKBAR']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_ta_lw_detectors = ['NRCALONG']\n",
+    "nrc_coron_ta_round_335_mask = ['MASK335R']\n",
+    "nrc_coron_ta_lw_round_335_filterpupils = ['F335M/MASKRND']\n",
+    "\n",
+    "nrc_coron_ta_round_430_mask = ['MASK430R']\n",
+    "nrc_coron_ta_lw_round_430_filterpupils = ['F335M/MASKRND']\n",
+    "\n",
+    "nrc_coron_ta_lw_bar_mask = ['MASKLWB']\n",
+    "nrc_coron_ta_lw_bar_filterpupils = ['F335M/MASKBAR']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Imaging Time Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_tsimg_ta_detectors = ['NRCBLONG']\n",
+    "nrc_tsimg_ta_subarrays = ['SUB32TATS']\n",
+    "nrc_tsimg_ta_filterpupils = ['F335M/CLEAR', 'F444W/F405N']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Grism Time Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_tsgrism_ta_detectors = ['NRCALONG']\n",
+    "nrc_tsgrism_ta_subarrays = ['SUB32TATSGRISM']\n",
+    "nrc_tsgrism_ta_filterpupils = ['F335M/CLEAR', 'F444W/F405N']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='taconf_params'></a>\n",
+    "### Target Acquisition Confirmation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These parameters match the coronagraphy TA parameters above.\n",
+    "Target Acquisition Confirmation data will be run though calwebb_detector1 and calwebb_image2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_ta_conf_exptype = 'NRC_TACONF'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_ta_conf_subarrays = ['SUB128', 'SUB64']\n",
+    "\n",
+    "nrc_ta_conf_sw_round_detectors = ['NRCA2']\n",
+    "nrc_ta_conf_sw_round_mask = ['MASK210R']\n",
+    "nrc_ta_conf_sw_round_filterpupils = ['F210M/MASKRND']\n",
+    "\n",
+    "nrc_ta_conf_sw_bar_detectors = ['NRCA4']\n",
+    "nrc_ta_conf_sw_bar_mask = ['MASKSWB']\n",
+    "nrc_ta_conf_sw_bar_filterpupils = ['F210M/MASKBAR']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_ta_conf_lw_detectors = ['NRCALONG']\n",
+    "nrc_ta_conf_lw_round_335_mask = ['MASK335R']\n",
+    "nrc_ta_conf_lw_round_335_filterpupils = ['F335M/MASKRND']\n",
+    "\n",
+    "nrc_ta_conf_lw_round_430_mask = ['MASK430R']\n",
+    "nrc_ta_conf_lw_round_430_filterpupils = ['F335M/MASKRND']\n",
+    "\n",
+    "nrc_ta_conf_lw_bar_mask = ['MASKLWB']\n",
+    "nrc_ta_conf_lw_bar_filterpupils = ['F335M/MASKBAR']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='focus_params'></a>\n",
+    "### Focus"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It appears that NRC_FOCUS data can be taken with any combination of filter/pupil (at least, they are all selectable in APT)\n",
+    "\n",
+    "These data will be processed through detector1 and image2 pipelines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_focus_exptype = 'NRC_FOCUS'\n",
+    "nrc_focus_sw_dets = ['NRCA1', 'NRCA2', 'NRCA3', 'NRCA4', 'NRCB1', 'NRCB2', 'NRCB3', 'NRCB4']\n",
+    "nrc_focus_sw_subarrays = ['FULL']\n",
+    "nrc_focus_sw_filterpupil = ['F070W/CLEAR', 'F090W/CLEAR', 'F115W/CLEAR', 'F150W/CLEAR', 'F150W2/CLEAR',\n",
+    "                            'F200W/CLEAR', 'F140M/CLEAR', 'F182M/CLEAR', 'F210M/CLEAR', 'F187N/CLEAR',\n",
+    "                            'F212N/CLEAR', 'WLP4/CLEAR', 'F150W2/F164N', 'F150W/F164N', 'F150W2/F162M',\n",
+    "                            \n",
+    "                            'F070W/WLP8', 'F090W/WLP8', 'F115W/WLP8', 'F150W/WLP8', 'F150W2/WLP8',\n",
+    "                            'F200W/WLP8', 'F140M/WLP8', 'F182M/WLP8', 'F210M/WLP8', 'F187N/WLP8',\n",
+    "                            'F212N/WLP8', 'WLP4/WLP8',\n",
+    "                            \n",
+    "                            'F070W/WLM8', 'F090W/WLM8', 'F115W/WLM8', 'F150W/WLM8', 'F150W2/WLM8',\n",
+    "                            'F200W/WLM8', 'F140M/WLM8', 'F182M/WLM8', 'F210M/WLM8', 'F187N/WLM8',\n",
+    "                            'F212N/WLM8', 'WLP4/WLM8',\n",
+    "                            \n",
+    "                            'F115W/GDHS0', 'F150W/GDHS0', 'F150W2/GDHS0',\n",
+    "                            'F200W/GDHS0', 'F140M/GDHS0', 'F182M/GDHS0', 'F210M/GDHS0', 'F187N/GDHS0',\n",
+    "                            'F212N/GDHS0', 'F115W/GDHS60', 'F150W/GDHS60', 'F150W2/GDHS60',\n",
+    "                            'F200W/GDHS60', 'F140M/GDHS60', 'F182M/GDHS60', 'F210M/GDHS60', 'F187N/GDHS60',\n",
+    "                            'F212N/GDHS60',\n",
+    "                           \n",
+    "                            'F070W/PINHOLES', 'F090W/PINHOLES', 'F115W/PINHOLES', 'F150W/PINHOLES',\n",
+    "                            'F150W2/PINHOLES', 'F200W/WLM8', 'F140M/PINHOLES', 'F182M/PINHOLES',\n",
+    "                            'F210M/PINHOLES', 'F187N/PINHOLES', 'F212N/WLM8', 'WLP4/PINHOLES',\n",
+    "                            \n",
+    "                            'F070W/MASKIPR', 'F090W/MASKIPR', 'F115W/MASKIPR', 'F150W/MASKIPR',\n",
+    "                            'F150W2/MASKIPR', 'F200W/MASKIPR', 'F140M/MASKIPR', 'F182M/MASKIPR',\n",
+    "                            'F210M/MASKIPR', 'F187N/MASKIPR', 'F212N/MASKIPR', 'WLP4/MASKIPR',\n",
+    "                            \n",
+    "                            'F200W/MASKRND', 'F182M/MASKRND', 'F210M/MASKRND', 'F187N/MASKRND',\n",
+    "                            'F212N/MASKRND',\n",
+    "                            \n",
+    "                            'F200W/MASKBAR', 'F182M/MASKBAR', 'F210M/MASKBAR', 'F187N/MASKBAR',\n",
+    "                            'F212N/MASKBAR']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_focus_lw_dets = ['NRCALONG', 'NRCBLONG']\n",
+    "nrc_focus_lw_subarrays = ['FULL']\n",
+    "nrc_focus_lw_filterpupil = ['F277W/CLEAR', 'F322W2/CLEAR', 'F356W/CLEAR', 'F444W/CLEAR',\n",
+    "                            'F250M/CLEAR', 'F300M/CLEAR',  'F335M/CLEAR', 'F360M/CLEAR',\n",
+    "                            'F410M/CLEAR', 'F430M/CLEAR', 'F460M/CLEAR',  'F480M/CLEAR',\n",
+    "                            'F322W2/F323N', 'F322W2/F405N', 'F410M/F405N', 'F444W/F466N',\n",
+    "                            'F444W/F470N',\n",
+    "                            \n",
+    "                            'F335M/F323N', 'F356W/F323N',\n",
+    "                            \n",
+    "                            'F410M/F405N',\n",
+    "                            'F460M/F466N', 'F480M/F466N',\n",
+    "                            'F480M/F470N',\n",
+    "                            \n",
+    "                            'F322W2/MASKRND', 'F356W/MASKRND', 'F444W/MASKRND',\n",
+    "                            'F250M/MASKRND', 'F300M/MASKRND', 'F335M/MASKRND',\n",
+    "                            'F360M/MASKRND', 'F410M/MASKRND', 'F430M/MASKRND',\n",
+    "                            'F460M/MASKRND',\n",
+    "                            \n",
+    "                            'F277W/MASKBAR', 'F356W/MASKBAR', 'F444W/MASKBAR',\n",
+    "                            'F250M/MASKBAR', 'F300M/MASKBAR', 'F335M/MASKBAR',\n",
+    "                            'F360M/MASKBAR', 'F410M/MASKBAR', 'F430M/MASKBAR',\n",
+    "                            'F460M/MASKBAR', 'F480M/MASKBAR',\n",
+    "                            \n",
+    "                            'F277W/MASKIPR', 'F322W2/MASKIPR', 'F356W/MASKIPR', 'F444W/MASKIPR',\n",
+    "                            'F250M/MASKIPR', 'F300M/MASKIPR',  'F335M/MASKIPR', 'F360M/MASKIPR',\n",
+    "                            'F410M/MASKIPR', 'F430M/MASKIPR', 'F460M/MASKIPR',  'F480M/MASKIPR',\n",
+    "                            \n",
+    "                            'F277W/GRISMR', 'F322W2/GRISMR', 'F356W/GRISMR', 'F444W/GRISMR',\n",
+    "                            'F250M/GRISMR', 'F300M/GRISMR',  'F335M/GRISMR', 'F360M/GRISMR',\n",
+    "                            'F410M/GRISMR', 'F430M/GRISMR', 'F460M/GRISMR',  'F480M/GRISMR',\n",
+    "                            \n",
+    "                            'F277W/GRISMC', 'F322W2/GRISMC', 'F356W/GRISMC', 'F444W/GRISMC',\n",
+    "                            'F250M/GRISMC', 'F300M/GRISMC',  'F335M/GRISMC', 'F360M/GRISMC',\n",
+    "                            'F410M/GRISMC', 'F430M/GRISMC', 'F460M/GRISMC',  'F480M/GRISMC',\n",
+    "                            \n",
+    "                            'F277W/PINHOLES', 'F322W2/PINHOLES', 'F356W/PINHOLES', 'F444W/PINHOLES',\n",
+    "                            'F250M/PINHOLES', 'F300M/PINHOLES',  'F335M/PINHOLES', 'F360M/PINHOLES',\n",
+    "                            'F410M/PINHOLES', 'F430M/PINHOLES', 'F460M/PINHOLES',  'F480M/PINHOLES'\n",
+    "                           ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='flat_params'></a>\n",
+    "### Flat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NRC_FLAT data will be processed through calwebb_detector1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_flat_exp_type = 'NRC_FLAT'\n",
+    "nrc_flat_sw_a_detectors = ['NRCA1', 'NRCA2', 'NRCA3', 'NRCA4']\n",
+    "nrc_flat_sw_a_subarrays = ['FULL']\n",
+    "\n",
+    "# Since these data will only be run through calwebb_detector1, there are no filter-dependent\n",
+    "# reference files to search for\n",
+    "nrc_flat_sw_a_filterpupils = ['F070W/CLEAR']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_flat_sw_b_detectors = ['NRCB1', 'NRCB2', 'NRCB3', 'NRCB4']\n",
+    "nrc_flat_sw_b_subarrays = ['FULL', 'SUB640', 'SUB320', 'SUB160', 'SUB400P', 'SUB160P', 'SUB64P']\n",
+    "\n",
+    "# Since these data will only be run through calwebb_detector1, there are no filter-dependent\n",
+    "# reference files to search for\n",
+    "nrc_flat_sw_b_filterpupils = ['F070W/CLEAR']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_flat_lw_a_detectors = ['NRCALONG']\n",
+    "nrc_flat_lw_a_subarrays = ['FULL']\n",
+    "\n",
+    "# Since these data will only be run through calwebb_detector1, there are no filter-dependent\n",
+    "# reference files to search for\n",
+    "nrc_flat_lw_a_filterpupils = ['F444W/CLEAR']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_flat_lw_b_detectors = ['NRCBLONG']\n",
+    "nrc_flat_lw_b_subarrays = ['FULL', 'SUB640', 'SUB320', 'SUB160', 'SUB400P', 'SUB160P', 'SUB64P']\n",
+    "\n",
+    "# Since these data will only be run through calwebb_detector1, there are no filter-dependent\n",
+    "# reference files to search for\n",
+    "nrc_flat_lw_b_filterpupils = ['F444W/CLEAR']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='led_params'></a>\n",
+    "### LED"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NRC_LED data will be processed through calwebb_detector1, so no need to worry about filter/pupil combinations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_led_exp_type = 'NRC_LED'\n",
+    "nrc_led_sw_detectors = ['NRCA1', 'NRCA2', 'NRCA3', 'NRCA4', 'NRCB1', 'NRCB2', 'NRCB3', 'NRCB4']\n",
+    "nrc_led_sw_subarrays = ['FULL']\n",
+    "nrc_led_sw_filterpupils = ['F070W/CLEAR']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_led_lw_detectors = ['NRCALONG', 'NRCBLONG']\n",
+    "nrc_led_lw_subarrays = ['FULL']\n",
+    "nrc_led_lw_filterpupils = ['F444W/CLEAR']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='grism_params'></a>\n",
+    "### NRC_GRISM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NRC_GRISM data will be processed through calwebb_detector1 - This exp_type should only come about when using engineering imaging with the grism in place."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_engimg_lw_grism_exp_type = 'NRC_GRISM'\n",
+    "nrc_engimg_lw_grism_detectors = ['NRCALONG', 'NRCBLONG']\n",
+    "nrc_engimg_lw_grism_subarrays = ['FULL', 'SUB640', 'SUB320', 'SUB160']\n",
+    "nrc_engimg_lw_grism_filterpupils = ['F277W/GRISMR', 'F322W2/GRISMR', 'F356W/GRISMR', 'F444W/GRISMR',\n",
+    "                                    'F250M/GRISMR', 'F300M/GRISMR', 'F335M/GRISMR', 'F360M/GRISMR',\n",
+    "                                    'F410M/GRISMR', 'F430M/GRISMR', 'F460M/GRISMR', 'F480M/GRISMR',\n",
+    "                                    'F277W/GRISMC', 'F322W2/GRISMC', 'F356W/GRISMC', 'F444W/GRISMC',\n",
+    "                                    'F250M/GRISMC', 'F300M/GRISMC', 'F335M/GRISMC', 'F360M/GRISMC',\n",
+    "                                    'F410M/GRISMC', 'F430M/GRISMC', 'F460M/GRISMC', 'F480M/GRISMC']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_engimg_lw_p_grism_detectors = ['NRCBLONG']\n",
+    "nrc_engimg_lw_p_grism_subarrays = ['SUB400P', 'SUB160P', 'SUB64P']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "<a id='function_definitions'></a>\n",
+    "## Function definitions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def batch_query(config_list, reffiles):\n",
+    "    \"\"\"Wrapper around query_crds so that it can be called on a list of\n",
+    "    configuration dictionaries.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    config_list : list\n",
+    "        List of instrument configuration dictionaries\n",
+    "        \n",
+    "    reffiles : list\n",
+    "        List of reference file types to search for\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    missing_files : dict\n",
+    "        Dictionary of missing reference files. Keys are backslash-separated lists\n",
+    "        of instrument configurations. Values are lists of the missing file types\n",
+    "    \"\"\"\n",
+    "    missing_files = {}\n",
+    "    missing = False\n",
+    "    for entry in config_list:\n",
+    "        query = query_crds(entry, reffiles)\n",
+    "        if 'MISSING' in query.values():\n",
+    "            missing = True\n",
+    "            missing_types = [filetype for filetype, val in query.items() if val == 'MISSING']\n",
+    "            key = dict_keys_to_string(entry)\n",
+    "            missing_files[key] = missing_types\n",
+    "            #for missed in missing_types:\n",
+    "            #    print('{} missing for: {}'.format(missed, entry))\n",
+    "\n",
+    "    if not missing:\n",
+    "        print('No missing reference files.')\n",
+    "        \n",
+    "    if missing:\n",
+    "        print(\"Some reference files are missing!\")\n",
+    "    \n",
+    "    return missing_files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_parameter_dict(exp_type, detector, subarray, filter_name, pupil_name,\n",
+    "                          coronmask_name=None, tso_visit=False):\n",
+    "    \"\"\"Create a dictionary to be used as input to the CRDS getreferences\n",
+    "    function \n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    exp_type : str\n",
+    "        Exposure type (e.g. NRC_IMAGE, NRC_TSGRISM)\n",
+    "        \n",
+    "    detector : str\n",
+    "        e.g. 'NRCA1', 'NRCBLONG'\n",
+    "        \n",
+    "    subarray : str\n",
+    "        Subarray name (e.g. 'FULL', 'SUBGRISM128')\n",
+    "        \n",
+    "    filter_name : str\n",
+    "        Filter. (e.g. 'F444W')\n",
+    "        \n",
+    "    pupil_name : str\n",
+    "        Pupil. (e.g. 'CLEAR')\n",
+    "        \n",
+    "    coronmask_name : str\n",
+    "        Coronagraphic mask (e.g. MASKBAR)\n",
+    "        \n",
+    "    tso_visit : bool\n",
+    "        Whether or not the case to search for is a TSO visit\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    crds_dict : dict\n",
+    "        Dictionary of information necessary to select refernce files\n",
+    "        via getreferences().\n",
+    "    \"\"\"\n",
+    "    crds_dict = {}\n",
+    "    crds_dict['INSTRUME'] = 'NIRCAM'\n",
+    "    crds_dict['READPATT'] = 'RAPID'\n",
+    "    crds_dict['EXP_TYPE'] = exp_type.upper()\n",
+    "    crds_dict['DETECTOR'] = detector.upper()\n",
+    "    crds_dict['SUBARRAY'] = subarray.upper()\n",
+    "    crds_dict['FILTER'] = filter_name.upper()\n",
+    "    crds_dict['PUPIL'] = pupil_name.upper()\n",
+    "    crds_dict['TSOVISIT'] = tso_visit\n",
+    "    \n",
+    "    if coronmask_name is not None:\n",
+    "        crds_dict['CORONMSK'] = coronmask_name.upper()\n",
+    "    \n",
+    "    if crds_dict['DETECTOR'] in ['NRCALONG', 'NRCBLONG']:\n",
+    "        crds_dict['CHANNEL'] = 'LONG'\n",
+    "    else:\n",
+    "        crds_dict['CHANNEL'] = 'SHORT'\n",
+    "\n",
+    "    # Use the current date and time in order to get the most recent\n",
+    "    # reference file\n",
+    "    crds_dict['DATE-OBS'] = datetime.date.today().isoformat()\n",
+    "    current_date = datetime.datetime.now()\n",
+    "    crds_dict['TIME-OBS'] = current_date.time().isoformat()\n",
+    "\n",
+    "    return crds_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def dict_keys_to_string(config):\n",
+    "    \"\"\"Given a dictionary, create a string composed of all the\n",
+    "    keys in the dictionary, separated by back slashes\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    config : dict\n",
+    "        Dictionary of instrument configuration info\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    combined_str : str\n",
+    "        String composed of all dictionary keys\n",
+    "    \"\"\"\n",
+    "    combined_str = ''\n",
+    "    for i, key in enumerate(config): \n",
+    "        if i < (len(config)-1): \n",
+    "            combined_str = combined_str + '{}/'.format(config[key]) \n",
+    "        else: \n",
+    "            combined_str = combined_str + config[key] \n",
+    "    return combined_str"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def list_of_dictionaries(exposure_type, detectors, subarrays, filterpupils,\n",
+    "                         coronmasks=[], tso_visit=False, detector1=False):\n",
+    "    \"\"\"Given lists of detectors, subarrays, filters, etc, generate a list of\n",
+    "    parameter dictionaries, each of which can be used to query CRDS. All\n",
+    "    combinations of the entered lists will be added to the list of dictionaries,\n",
+    "    unless the detector1 keyword is True. In that case, Filter/Pupil will be\n",
+    "    ignored since none of the calwebb_detector1 reference files depend on\n",
+    "    filter/pupil.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    exposure_type : str\n",
+    "        e.g. NRC_IMAGE\n",
+    "        \n",
+    "    detectors : list\n",
+    "        List of detectors e.g. ['NRCB1', 'NRCB2']\n",
+    "        \n",
+    "    subarrays : list\n",
+    "        List of subarrays e.g. ['FULL', 'SUB320']\n",
+    "        \n",
+    "    filterpupils : list\n",
+    "        List of filter/pupil strings e.g. ['F444W/CLEAR', 'F356W/CLEAR']\n",
+    "    \n",
+    "    coronmasks : list\n",
+    "        Optional list of coronagraphic masks e.g. ['MASKBAR']\n",
+    "        \n",
+    "    tso_visit : bool\n",
+    "        Whether or not the case to be searched is a TSO visit\n",
+    "        \n",
+    "    detector1 : bool\n",
+    "        If True, the dictionaries will be used for querying for calwebb_detector1\n",
+    "        reference files, which do not depend on filter. One filter and pupil\n",
+    "        value will be used rather than all combinations with all filters.\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    query_dicts : list\n",
+    "        List of CRDS-formatted dcitionaries\n",
+    "    \"\"\"\n",
+    "    query_dicts = []\n",
+    "    for detector in detectors:\n",
+    "        for subarray in subarrays:\n",
+    "            if detector1:\n",
+    "                filter_name, pupil_name = filterpupils[0].split('/')\n",
+    "                query_dicts.append(create_parameter_dict(exposure_type, detector, \n",
+    "                                                         subarray, filter_name, pupil_name,\n",
+    "                                                         tso_visit=tso_visit))                        \n",
+    "            else:\n",
+    "                for filterpupil in filterpupils:\n",
+    "                    filter_name, pupil_name = filterpupil.split('/')\n",
+    "                    if len(coronmasks) == 0:\n",
+    "                        query_dicts.append(create_parameter_dict(exposure_type, detector, \n",
+    "                                                                 subarray, filter_name, pupil_name,\n",
+    "                                                                 tso_visit=tso_visit))\n",
+    "                    else:\n",
+    "                        for coronmask in coronmasks:\n",
+    "                            query_dicts.append(create_parameter_dict(exposure_type, detector, \n",
+    "                                                                     subarray, filter_name,\n",
+    "                                                                     pupil_name,\n",
+    "                                                                     coronmask_name=coronmask,\n",
+    "                                                                     tso_visit=tso_visit))\n",
+    "    return query_dicts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def query_crds(parameter_dict, reffile_types):\n",
+    "    \"\"\"Query CRDS for a given set of reference files with a given set of instrument parameters\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    parameter_dict : dict\n",
+    "        Dictionary of instrument parameters to use in the query. Output of \n",
+    "        create_parameter_dict().\n",
+    "        \n",
+    "    reffile_types : list\n",
+    "        List of reference file types to look for.\n",
+    "    \"\"\"\n",
+    "    try:\n",
+    "        reffile_mapping = crds.getrecommendations(parameter_dict, reftypes=reffile_types)\n",
+    "    except CrdsLookupError as e:\n",
+    "        #raise ValueError((\"ERROR: CRDSLookupError when trying to find reference \"\n",
+    "        #                  \"files for parameters: {}\".format(parameter_dict)))\n",
+    "        pass\n",
+    "        \n",
+    "    # Check for missing files\n",
+    "    results = {}\n",
+    "    for key, value in reffile_mapping.items():\n",
+    "        if \"NOT FOUND No match found.\" in value:\n",
+    "            results[key] = 'MISSING'\n",
+    "        else:\n",
+    "            results[key] = reffile_mapping[key]\n",
+    "    return results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "<a id='create_combinations'></a>\n",
+    "## Create parameter dictionaries"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='imaging_combos'></a>\n",
+    "### Imaging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_image_sw_lvl1 = list_of_dictionaries(nrc_image_exptype, nrc_image_sw_dets,\n",
+    "                                         nrc_image_sw_subarrays, nrc_image_sw_filterpupil,\n",
+    "                                         detector1=True)\n",
+    "nrc_image_lw_lvl1 = list_of_dictionaries(nrc_image_exptype, nrc_image_lw_dets,\n",
+    "                                         nrc_image_lw_subarrays, nrc_image_lw_filterpupil,\n",
+    "                                         detector1=True)\n",
+    "nrc_image_sw_p_lvl1 = list_of_dictionaries(nrc_image_exptype, nrc_image_sw_p_dets,\n",
+    "                                           nrc_image_sw_p_subarrays, nrc_image_sw_p_filterpupil,\n",
+    "                                           detector1=True)\n",
+    "nrc_image_lw_p_lvl1 = list_of_dictionaries(nrc_image_exptype, nrc_image_lw_p_dets,\n",
+    "                                           nrc_image_lw_p_subarrays, nrc_image_lw_p_filterpupil,\n",
+    "                                           detector1=True)\n",
+    "nrc_image_lvl1 = nrc_image_sw_lvl1 + nrc_image_lw_lvl1 + nrc_image_sw_p_lvl1 + nrc_image_lw_p_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_image_sw_lvl2 = list_of_dictionaries(nrc_image_exptype, nrc_image_sw_dets,\n",
+    "                                         nrc_image_sw_subarrays, nrc_image_sw_filterpupil,\n",
+    "                                         detector1=False)\n",
+    "nrc_image_lw_lvl2 = list_of_dictionaries(nrc_image_exptype, nrc_image_lw_dets,\n",
+    "                                         nrc_image_lw_subarrays, nrc_image_lw_filterpupil,\n",
+    "                                         detector1=False)\n",
+    "nrc_image_sw_p_lvl2 = list_of_dictionaries(nrc_image_exptype, nrc_image_sw_p_dets,\n",
+    "                                           nrc_image_sw_p_subarrays, nrc_image_sw_p_filterpupil,\n",
+    "                                           detector1=False)\n",
+    "nrc_image_lw_p_lvl2 = list_of_dictionaries(nrc_image_exptype, nrc_image_lw_p_dets,\n",
+    "                                           nrc_image_lw_p_subarrays, nrc_image_lw_p_filterpupil,\n",
+    "                                           detector1=False)\n",
+    "nrc_image_lvl2 = nrc_image_sw_lvl2 + nrc_image_lw_lvl2 + nrc_image_sw_p_lvl2 + nrc_image_lw_p_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Number of calwebb_detector1 checks: ', len(nrc_image_lvl1))\n",
+    "print('Number of image2/3 checks: ', len(nrc_image_lvl2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='wfss_combos'></a>\n",
+    "### WFSS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_wfss_lvl1 = list_of_dictionaries(nrc_wfss_exptype, nrc_wfss_detectors,\n",
+    "                                         nrc_wfss_subarrays, nrc_wfss_lw_filterpupil,\n",
+    "                                         detector1=True)\n",
+    "nrc_wfss_lvl2 = list_of_dictionaries(nrc_wfss_exptype, nrc_wfss_detectors,\n",
+    "                                         nrc_wfss_subarrays, nrc_wfss_lw_filterpupil,\n",
+    "                                         detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='tsimage_combos'></a>\n",
+    "### Imaging Time Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_tsimg_sw_lvl1 = list_of_dictionaries(nrc_tsimg_exptype, nrc_tsimg_sw_detectors,\n",
+    "                                         nrc_tsimg_sw_subarrays, nrc_tsimg_sw_filterpupil,\n",
+    "                                         detector1=True)\n",
+    "nrc_tsimg_lw_lvl1 = list_of_dictionaries(nrc_tsimg_exptype, nrc_tsimg_lw_detectors,\n",
+    "                                         nrc_tsimg_lw_subarrays, nrc_tsimg_lw_filterpupil,\n",
+    "                                         detector1=True)\n",
+    "nrc_tsgrism_sw_lvl1 = list_of_dictionaries(nrc_tsimg_exptype, nrc_tsgrism_sw_detectors,\n",
+    "                                           nrc_tsgrism_sw_subarrays, nrc_tsgrism_sw_filterpupils,\n",
+    "                                           detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_tsimg_sw_lvl2 = list_of_dictionaries(nrc_tsimg_exptype, nrc_tsimg_sw_detectors,\n",
+    "                                         nrc_tsimg_sw_subarrays, nrc_tsimg_sw_filterpupil,\n",
+    "                                         detector1=False)\n",
+    "nrc_tsimg_lw_lvl2 = list_of_dictionaries(nrc_tsimg_exptype, nrc_tsimg_lw_detectors,\n",
+    "                                         nrc_tsimg_lw_subarrays, nrc_tsimg_lw_filterpupil,\n",
+    "                                         detector1=False)\n",
+    "nrc_tsgrism_sw_lvl2 = list_of_dictionaries(nrc_tsimg_exptype, nrc_tsgrism_sw_detectors,\n",
+    "                                           nrc_tsgrism_sw_subarrays, nrc_tsgrism_sw_filterpupils,\n",
+    "                                           detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='tsgrism_combos'></a>\n",
+    "### Grism Time Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_tsgrism_lw_lvl1 = list_of_dictionaries(nrc_tsgrism_exptype, nrc_tsgrism_lw_detectors,\n",
+    "                                           nrc_tsgrism_lw_subarrays, nrc_tsgrism_lw_filterpupil,\n",
+    "                                           detector1=True)\n",
+    "nrc_tsgrism_lw_lvl2 = list_of_dictionaries(nrc_tsgrism_exptype, nrc_tsgrism_lw_detectors,\n",
+    "                                           nrc_tsgrism_lw_subarrays, nrc_tsgrism_lw_filterpupil,\n",
+    "                                           detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='coron_combos'></a>\n",
+    "### Coronagraphy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_sw_round_lvl1 = list_of_dictionaries(nrc_coron_exptype, nrc_coron_sw_round_detectors,\n",
+    "                                               nrc_coron_sw_subarrays, nrc_coron_sw_round_filterpupils,\n",
+    "                                               detector1=True)\n",
+    "nrc_coron_sw_bar_lvl1 = list_of_dictionaries(nrc_coron_exptype, nrc_coron_sw_bar_detectors,\n",
+    "                                             nrc_coron_sw_subarrays, nrc_coron_sw_bar_filterpupils,\n",
+    "                                             detector1=True)\n",
+    "nrc_coron_lw_round_335_lvl1 = list_of_dictionaries(nrc_coron_exptype, nrc_coron_lw_detectors,\n",
+    "                                                   nrc_coron_lw_round_335_subarrays,\n",
+    "                                                   nrc_coron_lw_round_335_filterpupils,\n",
+    "                                                   detector1=True)\n",
+    "nrc_coron_lw_round_430_lvl1 = list_of_dictionaries(nrc_coron_exptype, nrc_coron_lw_detectors,\n",
+    "                                                   nrc_coron_lw_round_430_subarrays,\n",
+    "                                                   nrc_coron_lw_round_430_filterpupils,\n",
+    "                                                   detector1=True)\n",
+    "nrc_coron_lw_bar_lvl1 = list_of_dictionaries(nrc_coron_exptype, nrc_coron_lw_detectors,\n",
+    "                                                   nrc_coron_lw_bar_subarrays,\n",
+    "                                                   nrc_coron_lw_bar_filterpupils,\n",
+    "                                                   detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_sw_round_lvl2 = list_of_dictionaries(nrc_coron_exptype, nrc_coron_sw_round_detectors,\n",
+    "                                               nrc_coron_sw_subarrays, nrc_coron_sw_round_filterpupils,\n",
+    "                                               coronmasks=nrc_coron_sw_round_mask,\n",
+    "                                               detector1=False)\n",
+    "nrc_coron_sw_bar_lvl2 = list_of_dictionaries(nrc_coron_exptype, nrc_coron_sw_bar_detectors,\n",
+    "                                             nrc_coron_sw_subarrays, nrc_coron_sw_bar_filterpupils,\n",
+    "                                             coronmasks=nrc_coron_sw_bar_mask,\n",
+    "                                             detector1=False)\n",
+    "nrc_coron_lw_round_335_lvl2 = list_of_dictionaries(nrc_coron_exptype, nrc_coron_lw_detectors,\n",
+    "                                                   nrc_coron_lw_round_335_subarrays,\n",
+    "                                                   nrc_coron_lw_round_335_filterpupils,\n",
+    "                                                   coronmasks=nrc_coron_lw_round_335_mask,\n",
+    "                                                   detector1=False)\n",
+    "nrc_coron_lw_round_430_lvl2 = list_of_dictionaries(nrc_coron_exptype, nrc_coron_lw_detectors,\n",
+    "                                                   nrc_coron_lw_round_430_subarrays,\n",
+    "                                                   nrc_coron_lw_round_430_filterpupils,\n",
+    "                                                   coronmasks=nrc_coron_lw_round_430_mask,\n",
+    "                                                   detector1=False)\n",
+    "nrc_coron_lw_bar_lvl2 = list_of_dictionaries(nrc_coron_exptype, nrc_coron_lw_detectors,\n",
+    "                                             nrc_coron_lw_bar_subarrays,\n",
+    "                                             nrc_coron_lw_bar_filterpupils,\n",
+    "                                             coronmasks=nrc_coron_lw_bar_mask,   \n",
+    "                                             detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='engimg_combos'></a>\n",
+    "### Engineering Imaging"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Engineering imaging data are only processed through calwebb_detector1. Since none of the reference files used in there depend on filters or coronagraphic masks, we don't need to specify those here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_engimg_sw_lvl1 = list_of_dictionaries('NRC_IMAGE', nrc_engimg_sw_detectors ,\n",
+    "                                          nrc_engimg_sw_subarrays, nrc_engimg_sw_filterpupils,\n",
+    "                                          detector1=True)\n",
+    "nrc_engimg_lw_lvl1 = list_of_dictionaries('NRC_IMAGE', nrc_engimg_lw_detectors ,\n",
+    "                                          nrc_engimg_lw_subarrays, nrc_engimg_lw_filterpupils,\n",
+    "                                          detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_engimg_sw_coro_round_lvl1 = list_of_dictionaries('NRC_IMAGE', nrc_engimg_sw_round_detectors,\n",
+    "                                                     nrc_engimg_sw_round_subarrays,\n",
+    "                                                     nrc_engimg_sw_round_filterpupils,\n",
+    "                                                     #coronmasks=nrc_engimg_sw_round_mask,\n",
+    "                                                     detector1=True)\n",
+    "nrc_engimg_sw_coro_bar_lvl1 = list_of_dictionaries('NRC_IMAGE', nrc_engimg_sw_bar_detectors,\n",
+    "                                               nrc_engimg_sw_bar_subarrays,\n",
+    "                                               nrc_engimg_sw_bar_filterpupils,\n",
+    "                                               #coronmasks=nrc_engimg_sw_bar_mask,\n",
+    "                                               detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_engimg_lw_coro_round_335_lvl1 = list_of_dictionaries('NRC_IMAGE', nrc_engimg_lw_detectors,\n",
+    "                                                         nrc_engimg_lw_round_335_subarrays,\n",
+    "                                                         nrc_engimg_lw_round_335_filterpupils,\n",
+    "                                                         #coronmasks=nrc_engimg_lw_round_335_mask,\n",
+    "                                                         detector1=True)\n",
+    "nrc_engimg_lw_coro_round_430_lvl1 = list_of_dictionaries('NRC_IMAGE', nrc_engimg_lw_detectors,\n",
+    "                                                         nrc_engimg_lw_round_430_subarrays,\n",
+    "                                                         nrc_engimg_lw_round_430_filterpupils,\n",
+    "                                                         #coronmasks=nrc_engimg_lw_round_430_mask,\n",
+    "                                                         detector1=True)\n",
+    "nrc_engimg_lw_coro_bar_lvl1 = list_of_dictionaries('NRC_IMAGE', nrc_engimg_lw_detectors,\n",
+    "                                                   nrc_engimg_lw_bar_subarrays,\n",
+    "                                                   nrc_engimg_lw_bar_filterpupils,\n",
+    "                                                   #coronmasks=nrc_engimg_lw_bar_mask,\n",
+    "                                                   detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_engimg_fp_a3_lvl1 = list_of_dictionaries('NRC_IMAGE', nrc_engimg_fp_a3_detectors,\n",
+    "                                             nrc_engimg_fp_a3_subarrays,\n",
+    "                                             nrc_image_sw_filterpupil,\n",
+    "                                             detector1=True)\n",
+    "nrc_engimg_fp_b4_lvl1 = list_of_dictionaries('NRC_IMAGE', nrc_engimg_fp_b4_detectors,\n",
+    "                                             nrc_engimg_fp_b4_subarrays,\n",
+    "                                             nrc_image_sw_filterpupil,\n",
+    "                                             detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_engimg_dhs_a_lvl1 = list_of_dictionaries('NRC_IMAGE', nrc_engimg_dhs_a_detectors,\n",
+    "                                             nrc_engimg_dhs_a_subarrays,\n",
+    "                                             nrc_engimg_dhs_filterpupil,\n",
+    "                                             detector1=True)\n",
+    "nrc_engimg_dhs_b_lvl1 = list_of_dictionaries('NRC_IMAGE', nrc_engimg_dhs_b_detectors,\n",
+    "                                             nrc_engimg_dhs_b_subarrays,\n",
+    "                                             nrc_engimg_dhs_filterpupil,\n",
+    "                                             detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='dark_combos'></a>\n",
+    "### Darks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NRC_DARK data are only processed through a specialized version of calwebb_detector1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_dark_sw_lvl1 = list_of_dictionaries(nrc_dark_exptype, nrc_dark_sw_dets, \n",
+    "                                        nrc_dark_sw_subarrays, nrc_dark_sw_pupils,\n",
+    "                                        detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_dark_lw_lvl1 = list_of_dictionaries(nrc_dark_exptype, nrc_dark_lw_dets, \n",
+    "                                        nrc_dark_lw_subarrays, nrc_dark_lw_pupils,\n",
+    "                                        detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_dark_p_sw_subs_lvl1 = list_of_dictionaries(nrc_dark_exptype, nrc_dark_sw_p_dets,\n",
+    "                                        nrc_dark_p_subarrays, nrc_dark_sw_pupils,\n",
+    "                                        detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_dark_p_lw_subs_lvl1 = list_of_dictionaries(nrc_dark_exptype, nrc_dark_lw_p_dets,\n",
+    "                                        nrc_dark_p_subarrays, nrc_dark_lw_pupils,\n",
+    "                                        detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_dark_grismts_sw_lvl1 = list_of_dictionaries(nrc_dark_exptype, nrc_dark_grismts_sw_dets,\n",
+    "                                                nrc_dark_grismts_sw_subarrays, nrc_dark_sw_pupils,\n",
+    "                                                detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_dark_grismts_lw_lvl1 = list_of_dictionaries(nrc_dark_exptype, nrc_dark_grismts_lw_dets,\n",
+    "                                                nrc_dark_grismts_lw_subarrays, nrc_dark_lw_pupils,\n",
+    "                                                detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='ta_combos'></a>\n",
+    "### Target Acquisition"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_ta_sw_round_lvl1 = list_of_dictionaries(nrc_ta_exptype, nrc_coron_ta_round_detectors,\n",
+    "                                                  nrc_coron_ta_subarrays, nrc_coron_ta_sw_round_filterpupils,\n",
+    "                                                  coronmasks=nrc_coron_ta_round_mask, detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_ta_sw_bar_lvl1 = list_of_dictionaries(nrc_ta_exptype, nrc_coron_ta_bar_detectors,\n",
+    "                                                  nrc_coron_ta_subarrays, nrc_coron_ta_sw_bar_filterpupils,\n",
+    "                                                  coronmasks=nrc_coron_ta_bar_mask, detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_ta_lw_round_335_lvl1 = list_of_dictionaries(nrc_ta_exptype, nrc_coron_ta_lw_detectors,\n",
+    "                                                      nrc_coron_ta_subarrays,\n",
+    "                                                      nrc_coron_ta_lw_round_335_filterpupils,\n",
+    "                                                      coronmasks=nrc_coron_ta_round_335_mask,\n",
+    "                                                      detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_ta_lw_round_430_lvl1 = list_of_dictionaries(nrc_ta_exptype, nrc_coron_ta_lw_detectors,\n",
+    "                                                      nrc_coron_ta_subarrays,\n",
+    "                                                      nrc_coron_ta_lw_round_430_filterpupils,\n",
+    "                                                      coronmasks=nrc_coron_ta_round_430_mask,\n",
+    "                                                      detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_ta_lw_bar_lvl1 = list_of_dictionaries(nrc_ta_exptype, nrc_coron_ta_lw_detectors,\n",
+    "                                                nrc_coron_ta_subarrays,\n",
+    "                                                nrc_coron_ta_lw_bar_filterpupils,\n",
+    "                                                coronmasks=nrc_coron_ta_lw_bar_mask,\n",
+    "                                                detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_tsimg_ta_lvl1 = list_of_dictionaries(nrc_ta_exptype, nrc_tsimg_ta_detectors, \n",
+    "                                         nrc_tsimg_ta_subarrays, nrc_tsimg_ta_filterpupils,\n",
+    "                                         detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_tsgrism_ta_lvl1 = list_of_dictionaries(nrc_ta_exptype, nrc_tsgrism_ta_detectors, \n",
+    "                                           nrc_tsgrism_ta_subarrays, nrc_tsgrism_ta_filterpupils,\n",
+    "                                           detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_ta_sw_round_lvl2 = list_of_dictionaries(nrc_ta_exptype, nrc_coron_ta_round_detectors,\n",
+    "                                                  nrc_coron_ta_subarrays, nrc_coron_ta_sw_round_filterpupils,\n",
+    "                                                  coronmasks=nrc_coron_ta_round_mask, detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_ta_sw_bar_lvl2 = list_of_dictionaries(nrc_ta_exptype, nrc_coron_ta_bar_detectors,\n",
+    "                                                  nrc_coron_ta_subarrays, nrc_coron_ta_sw_bar_filterpupils,\n",
+    "                                                  coronmasks=nrc_coron_ta_bar_mask, detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_ta_lw_round_335_lvl2 = list_of_dictionaries(nrc_ta_exptype, nrc_coron_ta_lw_detectors,\n",
+    "                                                      nrc_coron_ta_subarrays,\n",
+    "                                                      nrc_coron_ta_lw_round_335_filterpupils,\n",
+    "                                                      coronmasks=nrc_coron_ta_round_335_mask,\n",
+    "                                                      detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_ta_lw_round_430_lvl2 = list_of_dictionaries(nrc_ta_exptype, nrc_coron_ta_lw_detectors,\n",
+    "                                                      nrc_coron_ta_subarrays,\n",
+    "                                                      nrc_coron_ta_lw_round_430_filterpupils,\n",
+    "                                                      coronmasks=nrc_coron_ta_round_430_mask,\n",
+    "                                                      detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_coron_ta_lw_bar_lvl2 = list_of_dictionaries(nrc_ta_exptype, nrc_coron_ta_lw_detectors,\n",
+    "                                                nrc_coron_ta_subarrays,\n",
+    "                                                nrc_coron_ta_lw_bar_filterpupils,\n",
+    "                                                coronmasks=nrc_coron_ta_lw_bar_mask,\n",
+    "                                                detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_tsimg_ta_lvl2 = list_of_dictionaries(nrc_ta_exptype, nrc_tsimg_ta_detectors, \n",
+    "                                         nrc_tsimg_ta_subarrays, nrc_tsimg_ta_filterpupils,\n",
+    "                                         detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_tsgrism_ta_lvl2 = list_of_dictionaries(nrc_ta_exptype, nrc_tsgrism_ta_detectors, \n",
+    "                                           nrc_tsgrism_ta_subarrays, nrc_tsgrism_ta_filterpupils,\n",
+    "                                           detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='taconfirm_combos'></a>\n",
+    "### Target Acquisition Confirmation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_ta_conf_sw_round_lvl1 = list_of_dictionaries(nrc_ta_conf_exptype, nrc_ta_conf_sw_round_detectors,\n",
+    "                                                 nrc_ta_conf_subarrays, nrc_ta_conf_sw_round_filterpupils,\n",
+    "                                                 coronmasks=nrc_ta_conf_sw_round_mask, detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_ta_conf_sw_bar_lvl1 = list_of_dictionaries(nrc_ta_conf_exptype, nrc_ta_conf_sw_bar_detectors,\n",
+    "                                                 nrc_ta_conf_subarrays, nrc_ta_conf_sw_bar_filterpupils,\n",
+    "                                                 coronmasks=nrc_ta_conf_sw_bar_mask, detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_ta_conf_lw_round_335_lvl1 = list_of_dictionaries(nrc_ta_conf_exptype, nrc_ta_conf_lw_detectors,\n",
+    "                                                     nrc_ta_conf_subarrays,\n",
+    "                                                     nrc_ta_conf_lw_round_335_filterpupils, \n",
+    "                                                     coronmasks=nrc_ta_conf_lw_round_335_mask,\n",
+    "                                                     detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_ta_conf_lw_round_430_lvl1 = list_of_dictionaries(nrc_ta_conf_exptype, nrc_ta_conf_lw_detectors,\n",
+    "                                                     nrc_ta_conf_subarrays,\n",
+    "                                                     nrc_ta_conf_lw_round_430_filterpupils, \n",
+    "                                                     coronmasks=nrc_ta_conf_lw_round_430_mask,\n",
+    "                                                     detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_ta_conf_lw_bar_lvl1 = list_of_dictionaries(nrc_ta_conf_exptype, nrc_ta_conf_lw_detectors,\n",
+    "                                               nrc_ta_conf_subarrays,\n",
+    "                                               nrc_ta_conf_lw_bar_filterpupils, \n",
+    "                                               coronmasks=nrc_ta_conf_lw_bar_mask,\n",
+    "                                               detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_ta_conf_sw_round_lvl2 = list_of_dictionaries(nrc_ta_conf_exptype, nrc_ta_conf_sw_round_detectors,\n",
+    "                                                 nrc_ta_conf_subarrays, nrc_ta_conf_sw_round_filterpupils,\n",
+    "                                                 coronmasks=nrc_ta_conf_sw_round_mask, detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_ta_conf_sw_bar_lvl2 = list_of_dictionaries(nrc_ta_conf_exptype, nrc_ta_conf_sw_bar_detectors,\n",
+    "                                                 nrc_ta_conf_subarrays, nrc_ta_conf_sw_bar_filterpupils,\n",
+    "                                                 coronmasks=nrc_ta_conf_sw_bar_mask, detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_ta_conf_lw_round_335_lvl2 = list_of_dictionaries(nrc_ta_conf_exptype, nrc_ta_conf_lw_detectors,\n",
+    "                                                     nrc_ta_conf_subarrays,\n",
+    "                                                     nrc_ta_conf_lw_round_335_filterpupils, \n",
+    "                                                     coronmasks=nrc_ta_conf_lw_round_335_mask,\n",
+    "                                                     detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_ta_conf_lw_round_430_lvl2 = list_of_dictionaries(nrc_ta_conf_exptype, nrc_ta_conf_lw_detectors,\n",
+    "                                                     nrc_ta_conf_subarrays,\n",
+    "                                                     nrc_ta_conf_lw_round_430_filterpupils, \n",
+    "                                                     coronmasks=nrc_ta_conf_lw_round_430_mask,\n",
+    "                                                     detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_ta_conf_lw_bar_lvl2 = list_of_dictionaries(nrc_ta_conf_exptype, nrc_ta_conf_lw_detectors,\n",
+    "                                               nrc_ta_conf_subarrays,\n",
+    "                                               nrc_ta_conf_lw_bar_filterpupils, \n",
+    "                                               coronmasks=nrc_ta_conf_lw_bar_mask,\n",
+    "                                               detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='focus_combos'></a>\n",
+    "### Focus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_focus_sw_lvl1 = list_of_dictionaries(nrc_focus_exptype, nrc_focus_sw_dets,\n",
+    "                                         nrc_focus_sw_subarrays,\n",
+    "                                         nrc_focus_sw_filterpupil, \n",
+    "                                         detector1=True)\n",
+    "                                         \n",
+    "nrc_focus_sw_lvl2 = list_of_dictionaries(nrc_focus_exptype, nrc_focus_sw_dets,\n",
+    "                                         nrc_focus_sw_subarrays,\n",
+    "                                         nrc_focus_sw_filterpupil, \n",
+    "                                         detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_focus_lw_lvl1 = list_of_dictionaries(nrc_focus_exptype, nrc_focus_lw_dets,\n",
+    "                                         nrc_focus_lw_subarrays,\n",
+    "                                         nrc_focus_lw_filterpupil, \n",
+    "                                         detector1=True)\n",
+    "                                         \n",
+    "nrc_focus_lw_lvl2 = list_of_dictionaries(nrc_focus_exptype, nrc_focus_lw_dets,\n",
+    "                                         nrc_focus_lw_subarrays,\n",
+    "                                         nrc_focus_lw_filterpupil, \n",
+    "                                         detector1=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='flat_combos'></a>\n",
+    "### Flat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_flat_sw_a_lvl1 = list_of_dictionaries(nrc_flat_exp_type, nrc_flat_sw_a_detectors,\n",
+    "                                          nrc_flat_sw_a_subarrays, nrc_flat_sw_a_filterpupils,\n",
+    "                                          detector1=True)\n",
+    "\n",
+    "nrc_flat_sw_b_lvl1 = list_of_dictionaries(nrc_flat_exp_type, nrc_flat_sw_b_detectors,\n",
+    "                                          nrc_flat_sw_b_subarrays, nrc_flat_sw_b_filterpupils,\n",
+    "                                          detector1=True)\n",
+    "\n",
+    "nrc_flat_lw_a_lvl1 = list_of_dictionaries(nrc_flat_exp_type, nrc_flat_lw_a_detectors,\n",
+    "                                          nrc_flat_lw_a_subarrays, nrc_flat_lw_a_filterpupils,\n",
+    "                                          detector1=True)\n",
+    "\n",
+    "nrc_flat_lw_b_lvl1 = list_of_dictionaries(nrc_flat_exp_type, nrc_flat_lw_b_detectors,\n",
+    "                                          nrc_flat_lw_b_subarrays, nrc_flat_lw_b_filterpupils,\n",
+    "                                          detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='led_combos'></a>\n",
+    "### LED"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_led_sw_lvl1 = list_of_dictionaries(nrc_led_exp_type, nrc_led_sw_detectors,\n",
+    "                                          nrc_led_sw_subarrays, nrc_led_sw_filterpupils,\n",
+    "                                          detector1=True)\n",
+    "\n",
+    "nrc_led_lw_lvl1 = list_of_dictionaries(nrc_led_exp_type, nrc_led_lw_detectors,\n",
+    "                                          nrc_led_lw_subarrays, nrc_led_lw_filterpupils,\n",
+    "                                          detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='grism_combos'></a>\n",
+    "### GRISM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nrc_grism_lw_lvl1 = list_of_dictionaries(nrc_engimg_lw_grism_exp_type, nrc_engimg_lw_grism_detectors,\n",
+    "                                          nrc_engimg_lw_grism_subarrays, nrc_engimg_lw_grism_filterpupils,\n",
+    "                                          detector1=True)\n",
+    "nrc_grism_lw_p_lvl1 = list_of_dictionaries(nrc_engimg_lw_grism_exp_type, nrc_engimg_lw_p_grism_detectors,\n",
+    "                                          nrc_engimg_lw_p_grism_subarrays, nrc_engimg_lw_grism_filterpupils,\n",
+    "                                          detector1=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "<a id='run_queries'></a>\n",
+    "## Query CRDS"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='imaging_queries'></a>\n",
+    "### Imaging"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Imaging mode data run through calwebb_detector1, calwebb_image2, and calwebb_image3, so we need to check for reference files associated with all three."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_image_lvl1 = batch_query(nrc_image_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_image_lvl2 = batch_query(nrc_image_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_image_lvl3 = batch_query(nrc_image_lvl2, level3_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='wfss_queries'></a>\n",
+    "### WFSS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_wfss_lvl1 = batch_query(nrc_wfss_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_wfss_lvl2 = batch_query(nrc_wfss_lvl2, level2a_grism_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_wfss_lvl3 = batch_query(nrc_wfss_lvl2, level3_wfss_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='tsimage_queries'></a>\n",
+    "### Imaging Time Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_tsimg_lvl1 = batch_query(nrc_tsimg_sw_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_tsimg_lvl1 = batch_query(nrc_tsimg_lw_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_tsgrism_lvl1 = batch_query(nrc_tsgrism_sw_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_tsimg_lvl2 = batch_query(nrc_tsimg_sw_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_tsimg_lvl2 = batch_query(nrc_tsimg_lw_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_tsgrism_lvl2 = batch_query(nrc_tsgrism_sw_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_tsimg_lvl3 = batch_query(nrc_tsimg_sw_lvl2, level3_tso_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_tsimg_lvl3 = batch_query(nrc_tsimg_lw_lvl2, level3_tso_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_tsgrism_lvl3 = batch_query(nrc_tsgrism_sw_lvl2, level3_tso_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='tsgrism_queries'></a>\n",
+    "### Grism Time Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_tsgrism_lvl1 = batch_query(nrc_tsgrism_lw_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_tsgrism_lvl2 = batch_query(nrc_tsgrism_lw_lvl2, level2a_grism_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_tsgrism_lvl3 = batch_query(nrc_tsgrism_lw_lvl2, level3_tso_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='coron_queries'></a>\n",
+    "### Coronagraphy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_coron_round_lvl1 = batch_query(nrc_coron_sw_round_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_coron_bar_lvl1 = batch_query(nrc_coron_sw_bar_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_round_335_lvl1 = batch_query(nrc_coron_lw_round_335_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_round_430_lvl1 = batch_query(nrc_coron_lw_round_430_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_bar_lvl1 = batch_query(nrc_coron_lw_bar_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_coron_round_lvl2 = batch_query(nrc_coron_sw_round_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_coron_bar_lvl2 = batch_query(nrc_coron_sw_bar_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_round_335_lvl2 = batch_query(nrc_coron_lw_round_335_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_round_430_lvl2 = batch_query(nrc_coron_lw_round_430_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_bar_lvl2 = batch_query(nrc_coron_lw_bar_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_coron_round_lvl3 = batch_query(nrc_coron_sw_round_lvl2, level3_coron_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_coron_bar_lvl3 = batch_query(nrc_coron_sw_bar_lvl2, level3_coron_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_round_335_lvl3 = batch_query(nrc_coron_lw_round_335_lvl2, level3_coron_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_round_430_lvl3 = batch_query(nrc_coron_lw_round_430_lvl2, level3_coron_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_bar_lvl3 = batch_query(nrc_coron_lw_bar_lvl2, level3_coron_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='engimg_queries'></a>\n",
+    "### Engineering Imaging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_sw_lvl1 = batch_query(nrc_engimg_sw_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_lw_lvl1 = batch_query(nrc_engimg_lw_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_sw_coro_round_lvl1 = batch_query(nrc_engimg_sw_coro_round_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_sw_coro_bar_lvl1 = batch_query(nrc_engimg_sw_coro_bar_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_lw_coro_round_335_lvl1 = batch_query(nrc_engimg_lw_coro_round_335_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_lw_coro_round_430_lvl1 = batch_query(nrc_engimg_lw_coro_round_430_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_lw_coro_bar_lvl1 = batch_query(nrc_engimg_lw_coro_bar_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "How important are the missing reference files above? Will anyone be using engineering imaging with the coronagraphic masks in place?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_fp_a3_lvl1 = batch_query(nrc_engimg_fp_a3_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_fp_b4_lvl1 = batch_query(nrc_engimg_fp_b4_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_dhs_a_lvl1 = batch_query(nrc_engimg_dhs_a_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_dhs_b_lvl1 = batch_query(nrc_engimg_dhs_b_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='dark_queries'></a>\n",
+    "### Darks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_dark_sw_lvl1 = batch_query(nrc_dark_sw_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_dark_lw_lvl1 = batch_query(nrc_dark_lw_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_dark_p_sw_lvl1 = batch_query(nrc_dark_p_sw_subs_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_dark_p_lw_lvl1 = batch_query(nrc_dark_p_lw_subs_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_dark_grismts_sw_lvl1 = batch_query(nrc_dark_grismts_sw_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_dark_grismts_lw_lvl1 = batch_query(nrc_dark_grismts_lw_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There must be more modes that need to be covered here?? Or since we're not subtracting a dark from these, all the reference files we are looking for are full-frame?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='ta_queries'></a>\n",
+    "### Target Acquisition"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_sw_round_lvl1 = batch_query(nrc_coron_ta_sw_round_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_sw_bar_lvl1 = batch_query(nrc_coron_ta_sw_bar_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_lw_round_335_lvl1 = batch_query(nrc_coron_ta_lw_round_335_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_lw_round_430_lvl1 = batch_query(nrc_coron_ta_lw_round_430_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_lw_bar_lvl1 = batch_query(nrc_coron_ta_lw_bar_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "TA files will eventually be processed through level 2b. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_sw_round_lvl2 = batch_query(nrc_coron_ta_sw_round_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_sw_bar_lvl2 = batch_query(nrc_coron_ta_sw_bar_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_lw_round_335_lvl2 = batch_query(nrc_coron_ta_lw_round_335_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_lw_round_430_lvl2 = batch_query(nrc_coron_ta_lw_round_430_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_lw_bar_lvl2 = batch_query(nrc_coron_ta_lw_bar_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='taconfirm_queries'></a>\n",
+    "### Target Acquisition Confirmation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_sw_round_lvl1 = batch_query(nrc_ta_conf_sw_round_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_sw_round_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_sw_bar_lvl1 = batch_query(nrc_ta_conf_sw_bar_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_sw_bar_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_lw_round_335_lvl1 = batch_query(nrc_ta_conf_lw_round_335_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_lw_round_335_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_lw_round_430_lvl1 = batch_query(nrc_ta_conf_lw_round_430_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_lw_round_430_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_lw_bar_lvl1 = batch_query(nrc_ta_conf_lw_bar_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_lw_bar_lvl1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "TA confirmation files will eventually also be processed through level 2b??"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_sw_round_lvl2 = batch_query(nrc_ta_conf_sw_round_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_sw_bar_lvl2 = batch_query(nrc_ta_conf_sw_bar_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_lw_round_335_lvl2 = batch_query(nrc_ta_conf_lw_round_335_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_lw_round_430_lvl2 = batch_query(nrc_ta_conf_lw_round_430_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_lw_bar_lvl2 = batch_query(nrc_ta_conf_lw_bar_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='focus_queries'></a>\n",
+    "### Focus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_focus_sw_lvl1 = batch_query(nrc_focus_sw_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_focus_sw_lvl2 = batch_query(nrc_focus_sw_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_focus_lw_lvl1 = batch_query(nrc_focus_lw_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_focus_lw_lvl2 = batch_query(nrc_focus_lw_lvl2, level2a_imaging_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='flat_queries'></a>\n",
+    "### Flat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_flat_sw_a_lvl1 = batch_query(nrc_flat_sw_a_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_flat_sw_b_lvl1 = batch_query(nrc_flat_sw_b_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_flat_lw_a_lvl1 = batch_query(nrc_flat_lw_a_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_flat_lw_b_lvl1 = batch_query(nrc_flat_lw_b_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='grism_queries'></a>\n",
+    "### GRISM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_grism_lw_lvl1 = batch_query(nrc_grism_lw_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_grism_p_lw_lvl1 = batch_query(nrc_grism_lw_p_lvl1, level1b_reffiles)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "<a id='final_summary'></a>\n",
+    "## Final Summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Imaging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_image_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_image_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_image_lvl3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### WFSS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_wfss_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_wfss_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_wfss_lvl3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Imaging Time Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_tsimg_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_tsimg_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_tsgrism_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_tsimg_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_tsimg_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_tsgrism_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_tsimg_lvl3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_tsimg_lvl3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_tsgrism_lvl3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Grism Time Series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_tsgrism_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_tsgrism_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_tsgrism_lvl3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Coronagraphy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_coron_round_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_coron_bar_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_round_335_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_round_430_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_bar_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_coron_round_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_coron_bar_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_round_335_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_round_430_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_bar_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_coron_round_lvl3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_sw_coron_bar_lvl3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_round_335_lvl3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_round_430_lvl3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_lw_coron_bar_lvl3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Engineering Imaging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_sw_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_lw_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_sw_coro_round_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_sw_coro_bar_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_lw_coro_round_335_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_lw_coro_round_430_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_lw_coro_bar_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_fp_a3_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_fp_b4_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_dhs_a_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_engimg_dhs_b_lvl1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='dark_queries'></a>\n",
+    "### Darks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_dark_sw_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_dark_lw_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_dark_p_sw_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_dark_p_lw_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_dark_grismts_sw_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_dark_grismts_lw_lvl1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='ta_queries'></a>\n",
+    "### Target Acquisition"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_sw_round_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_sw_bar_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_lw_round_335_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_lw_round_430_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_lw_bar_lvl1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "TA files will eventually be processed through level 2b. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_sw_round_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_sw_bar_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_lw_round_335_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_lw_round_430_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_nrc_ta_coron_lw_bar_lvl2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='taconfirm_queries'></a>\n",
+    "### Target Acquisition Confirmation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_sw_round_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_sw_bar_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_lw_round_335_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_lw_round_430_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_lw_bar_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_sw_round_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_sw_bar_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_lw_round_335_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_lw_round_430_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_ta_conf_lw_bar_lvl2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='focus_queries'></a>\n",
+    "### Focus"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_focus_sw_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_focus_sw_lvl2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_focus_lw_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_focus_lw_lvl2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='flat_queries'></a>\n",
+    "### Flat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_flat_sw_a_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_flat_sw_b_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_flat_lw_a_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_flat_lw_b_lvl1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='grism_queries'></a>\n",
+    "### GRISM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_grism_lw_lvl1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "missing_grism_p_lw_lvl1"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds a notebook that can be used to query CRDS for all supported combinations of exp_type/detector/subarray/filter/pupil/etc. 

The notebook is mostly complete, but there are probably some tweaks needed for some of the lesser used exp_types/observation templates, such as engineering imaging.