### PR TITLE
Update to use jwst_reffiles for bias and hotpix

### DIFF
--- a/nircam_calib/commissioning/NRC_09_darks/NRC09_analysis_hot_noisy_pixels.ipynb
+++ b/nircam_calib/commissioning/NRC_09_darks/NRC09_analysis_hot_noisy_pixels.ipynb
@@ -96,7 +96,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Follow instructions for downloading the latest version of the pipeline to get the necessary analysis tools. Activate your environment, and then add additional tools. Note that pipeline software is not guaranteed to work on Windows machines, but it *should* work, in theory. "
+    "Follow instructions for downloading the latest version of the pipeline to get the necessary analysis tools. Activate your environment, and then add additional tools. For this analysis, you will also need the bad pixel algorithm in the jwst_reffiles package, which is used to generate bad pixel masks. \n",
+    "\n",
+    "Note that pipeline software is not guaranteed to work on Windows machines, but it *should* work, in theory. "
    ]
   },
   {
@@ -118,9 +120,14 @@
     "pip install jwst==1.2.3\n",
     "```\n",
     "\n",
-    "and add additional tools used:\n",
+    "and add additional tools used that are not included in the ```jwst``` package:\n",
     "```python\n",
     "pip install ipython jupyter matplotlib pylint pandas\n",
+    "```\n",
+    "\n",
+    "and install [jwst_reffiles](https://jwst-reffiles.readthedocs.io/en/latest/official_bad_pixel_mask.html?highlight=hot%20pixel):\n",
+    "```python\n",
+    "pip install git+https://github.com/spacetelescope/jwst_reffiles.git\n",
     "```"
    ]
   },
@@ -143,11 +150,11 @@
     "import yaml\n",
     "from glob import glob\n",
     "from jwst import datamodels\n",
+    "from jwst.datamodels import dqflags\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "from astropy.io import fits, ascii\n",
-    "from astropy.time import Time\n",
-    "from astropy.io import fits\n",
+    "from jwst_reffiles.bad_pixel_mask.bad_pixel_mask import bad_pixels\n",
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.patches as patches\n",
     "from matplotlib.ticker import FuncFormatter, MaxNLocator\n",
@@ -166,7 +173,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Data will be downloaded from MAST using the code written by Mario Gennaro and Armin Rest, and stored in our NIRCam data location: **TBD**"
+    "Data will be downloaded from MAST using the code written by Mario Gennaro and Armin Rest, and stored in our NIRCam data location: **TBD**\n",
+    "\n",
+    "This analysis relies on ```rate```, ```fitopt```, ```jump``` file outputs for the dark exposures."
    ]
   },
   {
@@ -188,7 +197,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "files = glob(base_dir+ground+'/NRC*_484_*uncal.fits')"
+    "dark_rate_files = sorted(glob(base_dir+'*_rate.fits'))\n",
+    "dark_jump_files = sorted(glob(base_dir+'*_jump.fits'))\n",
+    "dark_fitopt_files = sorted(glob(base_dir+'*_fitopt.fits'))\n",
+    "dark_uncal_files = sorted(glob(base_dir+'*_uncal.fits'))"
    ]
   },
   {
@@ -196,14 +208,217 @@
    "metadata": {},
    "source": [
     "<a id='hot pixels'></a>\n",
-    "## Hot pixel investigation"
+    "## Hot and noisy pixel investigation"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Add Armin's scripts. "
+    "This section uses a collection of dark current exposures in order to search for NOISY, HOT, RC, TELEGRAPH, and LOW_PEDESTAL pixels. Both of these modules from ```jwst_reffiles``` expect input data in at least 2 calibration states: slope images, “fitopt” files, CR-flagged ramps (```rate```, ```fitopt```, ```jump``` files). Detailed [documentation about the software is here](https://jwst-reffiles.readthedocs.io/en/latest/official_bad_pixel_mask.html?highlight=hot%20pixel)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When running bad_pixel_mask.py as a standalone package, the input file lists described above must be provided manually. In the future, when running via ```mkrefs```, raw or partially-calibrated files will be allowed as inputs. ```mkrefs``` will then call the calibration pipeline and produce the needed files.\n",
+    "\n",
+    "To use the bad pixel mask generator function as a standalone package, we use the code shown below. Detailed descriptions of the keywords in the call are linked in the documentation. Note that all of the keywords in the call below have defaults defined in the code (and in fact the call below is using all default values), so you do not have to specify any keywords where you wish to use the default."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bad_pixels(dead_search =True,\n",
+    "           low_qe_and_open_search =True,\n",
+    "           dead_search_type ='sigma_rate',\n",
+    "           smoothing_box_width =15,\n",
+    "           smoothing_type ='Box2D',\n",
+    "           dead_sigma_threshold =5.,\n",
+    "           max_dead_norm_signal =None,\n",
+    "           run_dead_flux_check =False,\n",
+    "           dead_flux_check_files =None,\n",
+    "           flux_check =45000,\n",
+    "           max_low_qe_norm_signal =0.5,\n",
+    "           max_open_adj_norm_signal =1.05,\n",
+    "           manual_flag_file ='default',\n",
+    "           dark_slope_files=dark_rate_files,\n",
+    "           dark_uncal_files=None,\n",
+    "           dark_jump_files=dark_jump_files,\n",
+    "           dark_fitopt_files=dark_fitopt_files,\n",
+    "           dark_stdev_clipping_sigma =5.,\n",
+    "           dark_max_clipping_iters =5,\n",
+    "           dark_noisy_threshold =5,\n",
+    "           max_saturated_fraction =0.5,\n",
+    "           max_jump_limit =10,\n",
+    "           jump_ratio_threshold =5,\n",
+    "           early_cutoff_fraction =0.25,\n",
+    "           pedestal_sigma_threshold =5,\n",
+    "           rc_fraction_threshold =0.8,\n",
+    "           low_pedestal_fraction =0.8,\n",
+    "           high_cr_fraction =0.8,\n",
+    "           flag_values ={'hot': ['HOT'], 'rc': ['RC'], 'low_pedestal': ['OTHER_BAD_PIXEL'], 'high_cr': [\"TELEGRAPH\"]},\n",
+    "           dark_do_not_use =['hot', 'rc', 'low_pedestal', 'high_cr'],\n",
+    "           plot =False,\n",
+    "           output_file =analysis_dir+'test_bpm.fits',\n",
+    "           author ='jwst_reffiles',\n",
+    "           description ='A bad pix mask',\n",
+    "           pedigree ='GROUND',\n",
+    "           useafter ='2019-04-01 00:00:00',\n",
+    "           history ='',\n",
+    "           quality_check =False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now take the outputs from ```mkrefs``` to find the number of pixels flagged for NOISY, HOT, RC, TELEGRAPH, and LOW_PEDESTAL. The mask values recognized by the pipeline are listed [here](https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/references_general.html#data-quality-flags). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "output = datamodels.MaskModel('test_bpm.fits')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Hot pixels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hot = np.where(output.dq & dqflags.pixel['HOT'] > 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_hot_flags = len(hot[0])\n",
+    "print(('Found {} hot flags.'.format(num_hot_flags)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Noisy pixels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "noisy = np.where(output.dq & dqflags.pixel['NOISY'] > 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_noisy_flags = len(noisy[0])\n",
+    "print(('Found {} noisy flags.'.format(num_noisy_flags)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### RC pixels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rc = np.where(output.dq & dqflags.pixel['RC'] > 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_rc_flags = len(rc[0])\n",
+    "print(('Found {} rc flags.'.format(num_rc_flags)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Telegraph pixels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "telegraph = np.where(output.dq & dqflags.pixel['TELEGRAPH'] > 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_telegraph_flags = len(telegraph[0])\n",
+    "print(('Found {} telegraph flags.'.format(num_telegraph_flags)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Low pedestal pixels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "low_pedestal = np.where(output.dq & dqflags.pixel['LOW_PEDESTAL'] > 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_low_pedestal_flags = len(low_pedestal[0])\n",
+    "print(('Found {} low_pedestal flags.'.format(num_low_pedestal_flags)))"
    ]
   }
  ],

--- a/nircam_calib/commissioning/NRC_09_darks/NRC09_analysis_superbias.ipynb
+++ b/nircam_calib/commissioning/NRC_09_darks/NRC09_analysis_superbias.ipynb
@@ -97,7 +97,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Follow instructions for downloading the latest version of the pipeline to get the necessary analysis tools. Activate your environment, and then add additional tools. Note that pipeline software is not guaranteed to work on Windows machines, but it *should* work, in theory. "
+    "Follow instructions for downloading the latest version of the pipeline to get the necessary analysis tools. Activate your environment, and then add additional tools. For this analysis, you will also need the superbias algorithm in the jwst_reffiles package, which is used to generate superbias reference files. \n",
+    "\n",
+    "Note that pipeline software is not guaranteed to work on Windows machines, but it *should* work, in theory. "
    ]
   },
   {
@@ -119,9 +121,14 @@
     "pip install jwst==1.2.3\n",
     "```\n",
     "\n",
-    "and add additional tools used:\n",
+    "and add additional tools used that are not included in the ```jwst``` package:\n",
     "```python\n",
     "pip install ipython jupyter matplotlib pylint pandas\n",
+    "```\n",
+    "\n",
+    "and install [jwst_reffiles](https://jwst-reffiles.readthedocs.io/en/latest/official_bad_pixel_mask.html?highlight=hot%20pixel):\n",
+    "```python\n",
+    "pip install git+https://github.com/spacetelescope/jwst_reffiles.git\n",
     "```"
    ]
   },
@@ -144,15 +151,63 @@
     "import yaml\n",
     "from glob import glob\n",
     "from jwst import datamodels\n",
+    "from jwst.datamodels import dqflags\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "from astropy.io import fits, ascii\n",
-    "from astropy.time import Time\n",
-    "from astropy.io import fits\n",
+    "from astropy.visualization import ImageNormalize, ManualInterval, LogStretch\n",
+    "from jwst_reffiles.superbias import superbias\n",
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.patches as patches\n",
     "from matplotlib.ticker import FuncFormatter, MaxNLocator\n",
+    "\n",
     "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_image(data_2d, vmin, vmax, xpixel=None, ypixel=None, title=None):\n",
+    "    \"\"\"Hilbert's function to generate a 2D, log-scaled image of the data, \n",
+    "    with an option to highlight a specific pixel (with a red dot).\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    data_2d : numpy.ndarray\n",
+    "        Image to be displayed\n",
+    "        \n",
+    "    vmin : float\n",
+    "        Minimum signal value to use for scaling\n",
+    "        \n",
+    "    vmax : float\n",
+    "        Maximum signal value to use for scaling\n",
+    "        \n",
+    "    xpixel : int\n",
+    "        X-coordinate of pixel to highlight\n",
+    "        \n",
+    "    ypixel : int\n",
+    "        Y-coordinate of pixel to highlight\n",
+    "        \n",
+    "    title : str\n",
+    "        String to use for the plot title\n",
+    "    \"\"\"\n",
+    "    norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
+    "                          stretch=LogStretch())\n",
+    "    fig = plt.figure(figsize=(8, 8))\n",
+    "    ax = fig.add_subplot(1, 1, 1)\n",
+    "    im = ax.imshow(data_2d, origin='lower', norm=norm)\n",
+    "    \n",
+    "    if xpixel and ypixel:\n",
+    "        plt.plot(xpixel, ypixel, marker='o', color='red', label='Selected Pixel')\n",
+    "\n",
+    "    fig.colorbar(im, label='DN')\n",
+    "    plt.xlabel('Pixel column')\n",
+    "    plt.ylabel('Pixel row')\n",
+    "    if title:\n",
+    "        plt.title(title)"
    ]
   },
   {
@@ -167,7 +222,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Data will be downloaded from MAST using the code written by Mario Gennaro and Armin Rest, and stored in our NIRCam data location: **TBD**"
+    "Data will be downloaded from MAST using the code written by Mario Gennaro and Armin Rest, and stored in our NIRCam data location: **TBD**\n",
+    "\n",
+    "This analysis relies on ```dark``` file outputs for the dark exposures."
    ]
   },
   {
@@ -189,7 +246,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "files = glob(base_dir+ground+'/NRC*_484_*uncal.fits')"
+    "files = glob(base_dir+ground+'/NRC*_484_*.fits')"
    ]
   },
   {
@@ -204,7 +261,92 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Add Armin's scripts. "
+    "The superbias algorithm is the sigma-clipped mean of all 0th frames. The superbias error is the sigma-clipped stddev of all 0th frames. Pixels with high superbias error values are flagged as UNRELIABLE_BIAS and DO_NOT_USE in the superbias DQ array. Details about the algorithm and argument options are [in the documentation](https://jwst-reffiles.readthedocs.io/en/latest/api.html?highlight=superbias#module-jwst_reffiles.superbias.superbias). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_filename = 'superbias_jwst_reffiles.fits'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "superbias.make_superbias(files, clipping_sigma=3.0, max_clipping_iters=3, \n",
+    "                         bad_clipping_sigma=3.0, bad_max_clipping_iters=3, \n",
+    "                         bad_sigma_threshold=5.0, plot=False, save_filled=False, \n",
+    "                         box_width=3, save_reffile=True, outfile=output_filename, \n",
+    "                         author='jwst_reffiles', description='Super Bias Image', pedigree='GROUND', \n",
+    "                         useafter='2000-01-01T00:00:00', history='', subarray=None, readpatt=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bias = datamodels.SuperBiasModel(output_filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Check how many of the pixels were flagged "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "do_not_use = np.where(bias.dq & dqflags.pixel['DO_NOT_USE'] > 0)\n",
+    "unreliable = np.where(bias.dq & dqflags.pixel['UNRELIABLE_BIAS'] > 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_do_not_use_flags = len(do_not_use[0])\n",
+    "print(('Found {} do_not_use flags.'.format(num_do_not_use_flags)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_unreliable_flags = len(unreliable[0])\n",
+    "print(('Found {} unreliable flags.'.format(num_unreliable_flags)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Bias image "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(bias.data, vmin=0, vmax=5000)"
    ]
   }
  ],


### PR DESCRIPTION
Updated bias and hot pix notebooks to use jwst_reffile algorithms for analysis. 

	modified:   NRC09_analysis_hot_noisy_pixels.ipynb
	modified:   NRC09_analysis_superbias.ipynb

Cell outputs were cleared. 