### PR TITLE
Update to use jwst_reffiles for readnoise

### DIFF
--- a/nircam_calib/commissioning/NRC_09_darks/NRC09_analysis_readnoise_1overf_noise.ipynb
+++ b/nircam_calib/commissioning/NRC_09_darks/NRC09_analysis_readnoise_1overf_noise.ipynb
@@ -98,7 +98,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Follow instructions for downloading the latest version of the pipeline to get the necessary analysis tools. Activate your environment, and then add additional tools. Note that pipeline software is not guaranteed to work on Windows machines, but it *should* work, in theory. "
+    "Follow instructions for downloading the latest version of the pipeline to get the necessary analysis tools. Activate your environment, and then add additional tools. For this analysis, you will also need the readnoise algorithm in the jwst_reffiles package, which is used to generate readnoise reference files. \n",
+    "\n",
+    "Note that pipeline software is not guaranteed to work on Windows machines, but it *should* work, in theory. "
    ]
   },
   {
@@ -120,9 +122,14 @@
     "pip install jwst==1.2.3\n",
     "```\n",
     "\n",
-    "and add additional tools used:\n",
+    "and add additional tools used that are not included in the ```jwst``` package:\n",
     "```python\n",
     "pip install ipython jupyter matplotlib pylint pandas\n",
+    "```\n",
+    "\n",
+    "and install [jwst_reffiles](https://jwst-reffiles.readthedocs.io/en/latest/official_bad_pixel_mask.html?highlight=hot%20pixel):\n",
+    "```python\n",
+    "pip install git+https://github.com/spacetelescope/jwst_reffiles.git\n",
     "```"
    ]
   },
@@ -145,15 +152,63 @@
     "import yaml\n",
     "from glob import glob\n",
     "from jwst import datamodels\n",
+    "from jwst.datamodels import dqflags\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "from astropy.io import fits, ascii\n",
-    "from astropy.time import Time\n",
-    "from astropy.io import fits\n",
+    "from astropy.visualization import ImageNormalize, ManualInterval, LogStretch\n",
+    "from jwst_reffiles.readnoise import readnoise\n",
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.patches as patches\n",
     "from matplotlib.ticker import FuncFormatter, MaxNLocator\n",
+    "\n",
     "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_image(data_2d, vmin, vmax, xpixel=None, ypixel=None, title=None):\n",
+    "    \"\"\"Hilbert's function to generate a 2D, log-scaled image of the data, \n",
+    "    with an option to highlight a specific pixel (with a red dot).\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    data_2d : numpy.ndarray\n",
+    "        Image to be displayed\n",
+    "        \n",
+    "    vmin : float\n",
+    "        Minimum signal value to use for scaling\n",
+    "        \n",
+    "    vmax : float\n",
+    "        Maximum signal value to use for scaling\n",
+    "        \n",
+    "    xpixel : int\n",
+    "        X-coordinate of pixel to highlight\n",
+    "        \n",
+    "    ypixel : int\n",
+    "        Y-coordinate of pixel to highlight\n",
+    "        \n",
+    "    title : str\n",
+    "        String to use for the plot title\n",
+    "    \"\"\"\n",
+    "    norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
+    "                          stretch=LogStretch())\n",
+    "    fig = plt.figure(figsize=(8, 8))\n",
+    "    ax = fig.add_subplot(1, 1, 1)\n",
+    "    im = ax.imshow(data_2d, origin='lower', norm=norm)\n",
+    "    \n",
+    "    if xpixel and ypixel:\n",
+    "        plt.plot(xpixel, ypixel, marker='o', color='red', label='Selected Pixel')\n",
+    "\n",
+    "    fig.colorbar(im, label='DN')\n",
+    "    plt.xlabel('Pixel column')\n",
+    "    plt.ylabel('Pixel row')\n",
+    "    if title:\n",
+    "        plt.title(title)"
    ]
   },
   {
@@ -190,7 +245,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "files = glob(base_dir+ground+'/NRC*_484_*uncal.fits')"
+    "# files = glob(base_dir+ground+'/NRC*_484_*uncal.fits')\n",
+    "files = glob(\"*linearitystep.fits\")"
    ]
   },
   {
@@ -205,7 +261,77 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Add Ben's scripts. "
+    "[Visit the documentation](https://jwst-reffiles.readthedocs.io/en/latest/api.html?highlight=superbias#module-jwst_reffiles.readnoise.readnoise) for more information on the readnoise algorithm. This module creates a readnoise reference file that can be used in the JWST calibration pipeline. Two different methods can be used:\n",
+    "\n",
+    "Method 1 (method=’stack’): Create CDS images for each input ramp. Stack all of these images from each input ramp together. The readnoise is the sigma-clipped standard deviation through this master CDS image stack.\n",
+    "\n",
+    "Method 2 (method=’ramp’): Calculate the readnoise in each ramp individually, and then average these readnoise images together to produce a final readnoise map.\n",
+    "\n",
+    "We will use these tools to investigate the readnoise. Details about the arguments for the tools are included in the documentation. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_filename = 'readnoise_jwst_reffiles.fits'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Choose a method to use. Repeat the exercise with the other method if necessary. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "choose_method = 'stack'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "readnoise.make_readnoise(files, method=choose_method, group_diff_type='independent', \n",
+    "                         clipping_sigma=3.0, max_clipping_iters=3, nproc=1, slice_width=50, \n",
+    "                         single_value=False, outfile=output_filename, \n",
+    "                         author='jwst_reffiles', description='CDS Noise Image', pedigree='GROUND', \n",
+    "                         useafter='2015-10-01T00:00:00', history='', subarray=None, readpatt=None, \n",
+    "                         save_tmp=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Readnoise image "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "readnoise = datamodels.ReadnoiseModel(output_filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(readnoise.data, vmin=5, vmax=100)"
    ]
   },
   {


### PR DESCRIPTION
Updated the readnoise notebook to use jwst_reffile tools.

modified:   NRC09_analysis_readnoise_1overf_noise.ipynb

Cell outputs were cleared. 