### PR TITLE
Updated dark with placeholder jwst_reffiles tool

### DIFF
--- a/nircam_calib/commissioning/NRC_09_darks/NRC09_analysis_noise_stability_dark_current_performance.ipynb
+++ b/nircam_calib/commissioning/NRC_09_darks/NRC09_analysis_noise_stability_dark_current_performance.ipynb
@@ -98,7 +98,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Follow instructions for downloading the latest version of the pipeline to get the necessary analysis tools. Activate your environment, and then add additional tools. Note that pipeline software is not guaranteed to work on Windows machines, but it *should* work, in theory. "
+    "Follow instructions for downloading the latest version of the pipeline to get the necessary analysis tools. Activate your environment, and then add additional tools. For this analysis, you will also need the dark current tools in the jwst_reffiles package, which is used to generate dark current reference files. \n",
+    "\n",
+    "Note that pipeline software is not guaranteed to work on Windows machines, but it *should* work, in theory. "
    ]
   },
   {
@@ -120,9 +122,14 @@
     "pip install jwst==1.2.3\n",
     "```\n",
     "\n",
-    "and add additional tools used:\n",
+    "and add additional tools used that are not included in the ```jwst``` package:\n",
     "```python\n",
     "pip install ipython jupyter matplotlib pylint pandas\n",
+    "```\n",
+    "\n",
+    "and install [jwst_reffiles](https://jwst-reffiles.readthedocs.io/en/latest/official_bad_pixel_mask.html?highlight=hot%20pixel):\n",
+    "```python\n",
+    "pip install git+https://github.com/spacetelescope/jwst_reffiles.git\n",
     "```"
    ]
   },
@@ -145,15 +152,115 @@
     "import yaml\n",
     "from glob import glob\n",
     "from jwst import datamodels\n",
+    "from jwst.datamodels import dqflags\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "from astropy.io import fits, ascii\n",
-    "from astropy.time import Time\n",
-    "from astropy.io import fits\n",
+    "from jwst_reffiles.dark_current import dark_reffile\n",
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.patches as patches\n",
     "from matplotlib.ticker import FuncFormatter, MaxNLocator\n",
     "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_jump(signal, jump_group, xpixel=None, ypixel=None, slope=None):\n",
+    "    \"\"\"Hilbert's function to plot the signal up the ramp for a\n",
+    "    pixel and show the location of flagged jumps.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    signal : numpy.ndarray\n",
+    "        1D array of signal values\n",
+    "        \n",
+    "    jump_group : list\n",
+    "        List of boolean values whether a jump is present or\n",
+    "        not in each group\n",
+    "        \n",
+    "    slope : numpy.ndarray\n",
+    "        1D array of signal values constructed from the slope\n",
+    "    \"\"\"\n",
+    "    groups = np.arange(len(signal))\n",
+    "    fig = plt.figure(figsize=(6, 6))\n",
+    "    ax = plt.subplot()\n",
+    "\n",
+    "    plt.plot(groups, signal, marker='o', color='black')\n",
+    "    plt.plot(groups[jump_group], signal[jump_group], marker='o', color='red',\n",
+    "             label='Flagged Jump')\n",
+    "    \n",
+    "    if slope is not None:\n",
+    "        plt.plot(groups, slope, marker='o', color='blue', label='Data from slope')\n",
+    "        \n",
+    "    plt.legend(loc=2)\n",
+    "\n",
+    "    plt.xlabel('Groups')\n",
+    "    plt.ylabel('Signal (DN)')\n",
+    "    fig.tight_layout()\n",
+    "    plt.subplots_adjust(top=0.95)\n",
+    "    \n",
+    "    if xpixel and ypixel:\n",
+    "        plt.title('Pixel ('+str(xpixel)+','+str(ypixel)+')')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_jumps(signals, jump_groups, pixel_loc, slopes=None):\n",
+    "    \"\"\"Hilbert's function to plot the ramp and show the jump location\n",
+    "    for several pixels. For simplicity, let's force the input\n",
+    "    number of pixels to be a square. \n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    signals : numpy.ndarray\n",
+    "        2D array (groups x pix) of signal values\n",
+    "        \n",
+    "    jump_groups : numpy.ndarray\n",
+    "        2D array containing boolean entries for each group of\n",
+    "        each pixel, describing where the jumps were found\n",
+    "        \n",
+    "    pixel_loc : list\n",
+    "        List of 2-tuples containing the (x, y)\n",
+    "        location of the pixels with the jumps\n",
+    "        \n",
+    "    slopes : numpy.ndarray\n",
+    "        2D array (groups x pix) of linear signal values\n",
+    "        If not None, these will be overplotted onto the\n",
+    "        plots of signals\n",
+    "    \"\"\"\n",
+    "    num_group, num_pix = signals.shape\n",
+    "    root = np.sqrt(num_pix)\n",
+    "    if int(root + 0.5) ** 2 != num_pix:\n",
+    "        raise ValueError('Number of pixels input should be a square.')\n",
+    "    \n",
+    "    root = int(root)\n",
+    "    groups = np.arange(num_group)\n",
+    "    fig, axs = plt.subplots(root, root, figsize=(10, 10))\n",
+    "\n",
+    "    for index in range(len(pixel_loc)):\n",
+    "        i = int(index % root)\n",
+    "        j = int(index / root)\n",
+    "        axs[i, j].plot(groups, signals[:, index], marker='o', color='black')\n",
+    "        j_grp = jump_groups[:, index]\n",
+    "        axs[i, j].plot(groups[j_grp], signals[j_grp, index],\n",
+    "                       marker='o', color='red')\n",
+    "        \n",
+    "        if slopes is not None:\n",
+    "            axs[i, j].plot(groups, slopes[:, index], marker='o', color='blue')\n",
+    "        \n",
+    "        axs[i, j].set_title('Pixel ({}, {})'.format(pixel_loc[index][1], pixel_loc[index][0]))\n",
+    "        \n",
+    "    plt.xlabel('Groups')\n",
+    "    plt.ylabel('Signal (DN)')\n",
+    "    fig.tight_layout()"
    ]
   },
   {
@@ -168,7 +275,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Data will be downloaded from MAST using the code written by Mario Gennaro and Armin Rest, and stored in our NIRCam data location: **TBD**"
+    "Data will be downloaded from MAST using the code written by Mario Gennaro and Armin Rest, and stored in our NIRCam data location: **TBD**\n",
+    "\n",
+    "This analysis relies a list of exposures that have been through the following pipeline steps:\n",
+    "\n",
+    "* dq_init\n",
+    "* saturation\n",
+    "* superbias\n",
+    "* refpix\n",
+    "* linearity\n",
+    "* jump \n",
+    "* persistence"
    ]
   },
   {
@@ -190,7 +307,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "files = glob(base_dir+ground+'/NRC*_484_*uncal.fits')"
+    "dark_files = sorted(glob(base_dir+'*_dark.fits'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# files = glob(base_dir+ground+'/NRC*_484_*uncal.fits')\n",
+    "# files = glob(\"*linearitystep.fits\")\n",
+    "files = glob(\"/Users/acanipe/jwebbinars/data_files/*jump*fits\")\n",
+    "files"
    ]
   },
   {
@@ -205,7 +334,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Expected dark current values are shown in the table below. "
+    "Expected dark current values based on ground data are shown in the table below. "
    ]
   },
   {
@@ -222,7 +351,43 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Add Ben's scripts. "
+    "The dark current function creates a dark current reference file in the proper format. Details are in [the documentation](https://jwst-reffiles.readthedocs.io/en/latest/api.html?highlight=dark%20current#module-jwst_reffiles.dark_current.dark_reffile).\n",
+    "\n",
+    "The steps are:\n",
+    "\n",
+    "1. Get file headers from each file. Check for consistency. Extract CR flags from the JUMP version of the files.\n",
+    "\n",
+    "2. From these, create arrays giving the group number of the first cosmic ray hit in each pixel for each integration.\n",
+    "\n",
+    "3. Create images of how many dark current measurements are considered good for each pixel and each group. All groups after the first CR hit in a pixel are considered bad and not used.\n",
+    "\n",
+    "4. Read in the data. To avoid memory problems only read in N groups at a time, where N is determined from user inputs.\n",
+    "\n",
+    "5. Flag all groups that occur between the first CR hit and the end of the integration as bad.\n",
+    "\n",
+    "6. From the remaining good data, calculate the sigma-clipped mean dark signal in each pixel for each group (i.e. take the mean across integrations). Also calculate the sigma-clipped stdard deviation.\n",
+    "\n",
+    "7. Save the sigma-clipped mean as the dark data, and the sigma-clipped stdev as the uncertainty in a DarkModel instance. The DQ array is currently all zeros, anticipating bad pixels being placed in the bad pixel reference file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_file = analysis_dir+\"test_dark.fits\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dark_reffile(file_list=files, max_equivalent_groups=60, sigma_threshold=3, \n",
+    "             pedigree=None, descrip=None, author=None, use_after=None, history=None, \n",
+    "             output_file=output_file)"
    ]
   },
   {
@@ -237,7 +402,139 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Add Karl's scripts."
+    "For now, use the JWST pipeline jump detection algorithm and jump scripts from Hilbert, and eventually we will suplement this with Misselt's analysis. The jump step should have been run on the input data for the anlaysis above (our input dark current exposures). More information on the jump detection algorithm is in [the documentation](https://jwst-pipeline.readthedocs.io/en/latest/jwst/jump/index.html). "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Start by finding which pixels have been flagged with jumps. For our tests we will choose on of the input files. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_case = files[0]\n",
+    "jump = datamodels.RampModel(test_case)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find total number of jump flags added (including some pixels\n",
+    "# that have multiple groups flagged).\n",
+    "jump_flags = np.where(jump.groupdq & dqflags.pixel['JUMP_DET'] > 0)\n",
+    "print('{} jump flags detected.'.format(len(jump_flags[0])))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create 4D map of the jump flags and collapse to 2D map for the number of jumps per pixel \n",
+    "jump_map = (jump.groupdq & dqflags.pixel['JUMP_DET'] > 0)\n",
+    "jump_map_2d = np.sum(jump_map[0, :, :, :], axis=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find how many pixels have jump flags\n",
+    "jump_map_indexes = np.where(jump_map_2d > 0)\n",
+    "impacted_pix = np.sum(jump_map_2d > 0)\n",
+    "total_pix = jump.meta.subarray.ysize * jump.meta.subarray.xsize\n",
+    "print(('{} pixels ({:.2f}% of the detector) have been flagged with '\n",
+    "      'at least one jump.'.format(impacted_pix, 100. * impacted_pix / total_pix)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Look at some of the pixels. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an array of groups for the x-axis \n",
+    "group_indexes = np.arange(jump_map.shape[1]).astype(int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pick one pixel with a flagged jump, and find the group(s) with the jump flags\n",
+    "j_index = 500\n",
+    "jumpy = jump_map_indexes[0][j_index]\n",
+    "jumpx = jump_map_indexes[1][j_index]\n",
+    "jump_grp = jump_map[0, :, jumpy, jumpx]\n",
+    "print('Jump located in group(s) {} of pixel ({}, {})'.format(group_indexes[jump_grp], jumpx, jumpy))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot the ramp for this pixel\n",
+    "plot_jump(jump.data[0, :, jumpy, jumpx], jump_grp, xpixel=jumpx, ypixel=jumpy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot a grid of some examples of flagged jumps. The red points are the groups with flagged jumps. These groups will be ignored in subsequent ramp-fitting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "indexes_to_plot = [200, 401, 600, 30010, 31000, 1202, 1400, 21600, 10112]\n",
+    "jump_data = np.zeros((jump.shape[1], len(indexes_to_plot)))\n",
+    "jump_grps = np.zeros((jump.shape[1], len(indexes_to_plot))).astype(bool)\n",
+    "jump_locs = []\n",
+    "for counter, idx in enumerate(indexes_to_plot):\n",
+    "    #integ, grp, y, x = jump_flags[idx]\n",
+    "    y = jump_map_indexes[0][idx]\n",
+    "    x = jump_map_indexes[1][idx]\n",
+    "    grp = jump_map[0, :, y, x]\n",
+    "\n",
+    "    jump_data[:, counter] = jump.data[0, :, y, x]\n",
+    "    jump_grps[:, counter] = grp\n",
+    "    jump_locs.append((x, y))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_jumps(jump_data, jump_grps, jump_locs)"
    ]
   },
   {


### PR DESCRIPTION
Updated dark notebook with placeholder jwst_reffiles call and included some of Hilbert's jump scripts from the imaging pipeline notebook to examine CRs.

modified:   NRC09_analysis_noise_stability_dark_current_performance.ipynb

Cell outputs were cleared. 