### PR TITLE
Allow distortion coeffs from input text file rather than from pysiaf

### DIFF
--- a/nircam_calib/reffile_creation/pipeline/distortion/make_all_imaging_distortion_reffiles_from_pysiaf.py
+++ b/nircam_calib/reffile_creation/pipeline/distortion/make_all_imaging_distortion_reffiles_from_pysiaf.py
@@ -9,7 +9,7 @@ nrc_a_apertures = ['NRCA{}_FULL'.format(i+1) for i in range(5)]
 nrc_b_apertures = ['NRCB{}_FULL'.format(i+1) for i in range(5)]
 nrc_apertures = nrc_a_apertures + nrc_b_apertures
 
-hist = ("This reference file was created from the distortion coefficients contained in pysiaf "
+hist = ("XXXXXTEST TESTXXXXXThis reference file was created from the distortion coefficients contained in pysiaf "
         "(and therefore the PRD) as of 24 Oct 2019. This includes the fix for the round trip (V2,V3 -> x,y -> V2, V3) error "
         "present in previous versions of the coefficients. This update is described in JIRA issues: "
         "JWSTSIAF-161, JWSTSIAF-123. pysiaf version 0.6.1 was used to access the appropriate "
@@ -18,15 +18,15 @@ hist = ("This reference file was created from the distortion coefficients contai
 
 #basedir = 'reference_files/distortion/24Oct2019_round_trip_error_fixed'
 
-hist = ("This reference file was created from the distortion coefficients contained in pysiaf "
+hist = ("XXXXTEST TESTXXXXThis reference file was created from the distortion coefficients contained in pysiaf "
         "version 0.13.0, which uses "
         "version 39 of the PRD. This version of the PRD makes use of the new <detector>_FULL_WEDGE_RND"
         "and <detector>_FULL_WEDGE_BAR parent apertures for coronagraphic observations. All "
         "distortion coefficients are calculated from ground based data.")
 
 
-basedir = '/grp/jwst/wit/nircam/reference_files/distortion/coron_distortion_files_2021_Sept'
-
+#basedir = '/grp/jwst/wit/nircam/reference_files/distortion/coron_distortion_files_2021_Sept'
+basedir = '/Users/hilbert/python_repos/distortion_reffile_creation_from_johannes_code'
 # IMAGING metadata-----------------------------------------------
 sw_imaging_pupil = ['CLEAR', 'F162M', 'F164N', 'GDHS0', 'GDHS60', 'WLM8', 'WLP8', 'PINHOLES', 'MASKIPR', 'FLAT']
 lw_imaging_pupil = ['CLEAR', 'F323N', 'F405N', 'F466N', 'F470N', 'PINHOLES', 'MASKIPR', 'GRISMR', 'GRISMC', 'FLAT']
@@ -39,7 +39,7 @@ sw_exptype = ['NRC_IMAGE', 'NRC_TSIMAGE', 'NRC_FLAT', 'NRC_LED',
               'NRC_DARK', 'NRC_WFSS', 'NRC_TSGRISM', 'NRC_GRISM']
 lw_exptype = sw_exptype #+ ['NRC_WFSS', 'NRC_TSGRISM', 'NRC_GRISM']
 
-for aperture in nrc_apertures:
+for aperture in ['NRCB4_FULL']: #nrc_apertures:
     detector, apname = aperture.split('_')
     outname = os.path.join(basedir, '{}_distortion.asdf'.format(aperture))
 
@@ -54,8 +54,10 @@ for aperture in nrc_apertures:
         #subarr = lw_imaging_subarr
         subarr = ['GENERIC']
         exp_type = lw_exptype
-
-    #ref.create_nircam_distortion(detector, apname, outname, pupil, subarr, exp_type, hist)
+    ref.create_nircam_distortion(detector, apname, outname, pupil, subarr, exp_type, hist, author='Hilbert',
+                                 descrip=descrip, pedigree='GROUND', useafter='2014-10-01T00:00:01',
+                                 dist_coeffs_file='distortion_coeffs_nrcb4_full_f200w_clear_jw01144001001_01101_00001_nrcb4_cal.txt')
+stop
 
 # CORONAGRAPHY metadata------------------------------------------
 # For coronagraphy, we expect the bar and round wedges to have different astrometric solutions,

--- a/nircam_calib/reffile_creation/pipeline/distortion/nircam_distortion_reffiles_from_pysiaf.py
+++ b/nircam_calib/reffile_creation/pipeline/distortion/nircam_distortion_reffiles_from_pysiaf.py
@@ -24,6 +24,7 @@ in units of arcseconds from the refrence pixel.
 
 """
 from asdf import AsdfFile
+from astropy.io import ascii
 from astropy.modeling.models import Polynomial2D, Mapping, Shift
 import astropy.units as u
 from jwst.datamodels import DistortionModel
@@ -36,7 +37,9 @@ import pysiaf
 
 
 def create_nircam_distortion(detector, aperture, outname, sci_pupil,
-                             sci_subarr, sci_exptype, history_entry):
+                             sci_subarr, sci_exptype, history_entry,
+                             author=None, descrip=None, pedigree=None,
+                             useafter=None, dist_coeffs_file=None):
     """
     Create an asdf reference file with all distortion components for the NIRCam imager.
 
@@ -49,10 +52,40 @@ def create_nircam_distortion(detector, aperture, outname, sci_pupil,
     ----------
     detector : str
         NRCB1, NRCB2, NRCB3, NRCB4, NRCB5, NRCA1, NRCA2, NRCA3, NRCA4, NRCA5
+
     aperture : str
         Name of the aperture/subarray. (e.g. FULL, SUB160, SUB320, SUB640, GRISM_F322W2)
+
     outname : str
         Name of output file.
+
+    sci_pupil : list
+        Pupil wheel values for which this distortion solution applies
+
+    sci_subarr : list
+        List of subarray/aperture names to which this distortion solution applies
+
+    sci_exptype : list
+        List of exposure types to which this distortion solution applies
+
+    history_entry : str
+        Text to be added as a HISTORY entry in the output reference file
+
+    author : str
+        Value to place in the output file's Author metadata entry
+
+    descrip : str
+        Text to place in the output file's DECRIP header keyword
+
+    pedgree : str
+        Value to place in the output file's PEDIGREE header keyword
+
+    useafter : str
+        Value to place in the output file's USEAFTER header keyword (e.g. "2014-10-01T00:00:01")
+    dist_coeffs_file : str
+        Name of ascii file (nominally output by jwst_fpa package) containing distortion
+        coefficients. If this is provided, the coefficients in this file are used, rather
+        than those in pysiaf.
 
     Examples
     --------
@@ -75,19 +108,38 @@ def create_nircam_distortion(detector, aperture, outname, sci_pupil,
     xshift, yshift = get_refpix(inst_siaf, full_aperture)
 
     # *****************************************************
-    # "Forward' transformations. science --> ideal --> V2V3
-    label = 'Sci2Idl'
-    #from_units = 'distorted pixels'
-    #to_units = 'arcsec'
+    # If the user provides files containing distortion coefficients
+    # (as output by the jwst_fpa package), use those rather than
+    # retrieving coefficients from siaf.
+    if dist_coeffs_file is not None:
+        coeff_tab = read_distortion_coeffs_file(dist_coeffs_file)
+        xcoeffs = convert_distortion_coeffs_table(coeff_tab, 'Sci2IdlX')
+        ycoeffs = convert_distortion_coeffs_table(coeff_tab, 'Sci2IdlY')
+        inv_xcoeffs = convert_distortion_coeffs_table(coeff_tab, 'Idl2SciX')
+        inv_ycoeffs = convert_distortion_coeffs_table(coeff_tab, 'Idl2SciY')
+    elif dist_coeffs_file is None:
+        xcoeffs, ycoeffs = get_distortion_coeffs('Sci2Idl', siaf)
+        inv_xcoeffs, inv_ycoeffs = get_distortion_coeffs('Idl2Sci', siaf)
 
-    xcoeffs, ycoeffs = get_distortion_coeffs(label, siaf)
+    # V3IdlYAngle and V2Ref, V3Ref should always be taken from the latest version
+    # of SIAF, rather than the output of jwst_fpa. Separate FGS/NIRISS analyses must
+    # be done in order to modify these values.
+    v3_ideal_y_angle = siaf.V3IdlYAngle * np.pi / 180.
+
+    # *****************************************************
+    # "Forward' transformations. science --> ideal --> V2V3
+    #label = 'Sci2Idl'
+    ##from_units = 'distorted pixels'
+    ##to_units = 'arcsec'
+
+    #xcoeffs, ycoeffs = get_distortion_coeffs(label, siaf)
 
     sci2idlx = Polynomial2D(degree, **xcoeffs)
     sci2idly = Polynomial2D(degree, **ycoeffs)
 
     # Get info for ideal -> v2v3 or v2v3 -> ideal model
     parity = siaf.VIdlParity
-    v3_ideal_y_angle = siaf.V3IdlYAngle * np.pi / 180.
+    #v3_ideal_y_angle = siaf.V3IdlYAngle * np.pi / 180.
     idl2v2v3x, idl2v2v3y = v2v3_model('ideal', 'v2v3', parity, v3_ideal_y_angle)
 
     # Finally, we need to shift by the v2,v3 value of the reference
@@ -96,18 +148,18 @@ def create_nircam_distortion(detector, aperture, outname, sci_pupil,
 
     # *****************************************************
     # 'Reverse' transformations. V2V3 --> ideal --> science
-    label = 'Idl2Sci'
-    #from_units = 'arcsec'
-    #to_units = 'distorted pixels'
+    #label = 'Idl2Sci'
+    ##from_units = 'arcsec'
+    ##to_units = 'distorted pixels'
 
-    xcoeffs, ycoeffs = get_distortion_coeffs(label, siaf)
+    #xcoeffs, ycoeffs = get_distortion_coeffs(label, siaf)
 
-    idl2scix = Polynomial2D(degree, **xcoeffs)
-    idl2sciy = Polynomial2D(degree, **ycoeffs)
+    idl2scix = Polynomial2D(degree, **inv_xcoeffs)
+    idl2sciy = Polynomial2D(degree, **inv_ycoeffs)
 
     # Get info for ideal -> v2v3 or v2v3 -> ideal model
-    parity = siaf.VIdlParity
-    v3_ideal_y_angle = siaf.V3IdlYAngle * np.pi / 180.
+    #parity = siaf.VIdlParity
+    #v3_ideal_y_angle = siaf.V3IdlYAngle * np.pi / 180.
     v2v32idlx, v2v32idly = v2v3_model('v2v3', 'ideal', parity, v3_ideal_y_angle)
 
     ##"Forward' transformations. science --> ideal --> V2V3
@@ -187,20 +239,39 @@ def create_nircam_distortion(detector, aperture, outname, sci_pupil,
     d.meta.instrument.detector = detector
     d.meta.telescope = 'JWST'
     d.meta.subarray.name = 'FULL'
-    d.meta.pedigree = 'GROUND'
+
+    if pedigree is None:
+        d.meta.pedigree = 'GROUND'
+    else:
+        if pedigree.upper() not in ['DUMMY', 'GROUND', 'FLIGHT']:
+            raise ValueError("Bad PEDIGREE value.")
+        d.meta.pedigree = pedigree.upper()
+
     d.meta.reftype = 'DISTORTION'
-    d.meta.author = 'B. Hilbert'
+
+    if author is None:
+        author = "B. Hilbert"
+    d.meta.author = author
+
     d.meta.litref = "https://github.com/spacetelescope/nircam_calib/nircam_calib/reffile_creation/pipeline/distortion/nircam_distortion_reffiles_from_pysiaf.py"
-    d.meta.description = "Coron mode distortion model from PRD version 39"
+
+    if descrip is None:
+        d.meta.description = "TEST OF UPDATED CODE"
+    else:
+        d.meta.description = descrip
+
     #d.meta.exp_type = exp_type
-    d.meta.useafter = "2014-10-01T00:00:01"
+    if useafter is None:
+        d.meta.useafter = "2014-10-01T00:00:01"
+    else:
+        d.meta.useafter = useafter
 
     # To be ready for the future where we will have filter-dependent solutions
     d.meta.instrument.filter = 'N/A'
 
     # Create initial HISTORY ENTRY
     sdict = {'name': 'nircam_distortion_reffiles_from_pysiaf.py',
-             'author': 'B.Hilbert',
+             'author': author,
              'homepage': 'https://github.com/spacetelescope/nircam_calib',
              'version': '0.0'}
 
@@ -213,6 +284,34 @@ def create_nircam_distortion(detector, aperture, outname, sci_pupil,
 
     d.save(outname)
     print("Output saved to {}".format(outname))
+
+
+def convert_distortion_coeffs_table(tab, label):
+    """Convert the one set of coefficients output by read_distortion_coeffs_file into
+    the proper dictionary format to be then saved in the reference file.
+
+    Parameters
+    ----------
+    tab : astropy.table.Table
+        Table containing all coefficients
+
+    label : str
+        e.g. 'Sci2IdlX'
+
+    Returns
+    -------
+    coeffs : dict
+        Dictionary of one set of coefficients (e.g. Sci2IdlX) from the input table.
+        Keys list the polynomial order numbers (e.g. c3_4)
+    """
+    coeffs = {}
+    for row in tab:
+        i = int(row["siaf_index"][0])
+        j = int(row["siaf_index"][1])
+        key = f'c{i-j}_{j}'
+        coeffs[key] = row[label]
+
+    return coeffs
 
 
 def get_distortion_coeffs(direction_label, siaf):
@@ -291,6 +390,78 @@ def get_v2v3ref(siaf_instance):
     v2ref = siaf_instance.V2Ref
     v3ref = siaf_instance.V3Ref
     return Shift(v2ref) & Shift(v3ref)
+
+
+def read_distortion_coeffs_file(filename):
+    """Read the file containing the table of distortion coefficients
+
+    Example:
+
+    # NIRCAM distortion coefficient file
+
+    # Source file: jw01144001001_01101_00001_nrcb4_cal.fits
+    # Aperture: NRCB4_FULL
+    # Filter/Pupil: F200W/CLEAR
+    # Generated 2022-01-25T16:16:04.533 utc
+    # by verap
+    #
+      AperName , siaf_index , exponent_x , exponent_y ,                Sci2IdlX ,                Sci2IdlY ,                Idl2SciX ,                Idl2SciY
+    NRCB4_FULL ,         00 ,          0 ,          0 ,                     0.0 ,                     0.0 ,                     0.0 ,                     0.0
+    NRCB4_FULL ,         10 ,          1 ,          0 ,    0.031281790934487304 ,  0.00014142457551002174 ,      31.967141087158005 ,    -0.14404661727118445
+    NRCB4_FULL ,         11 ,          0 ,          1 ,                     0.0 ,    0.031447520345431045 ,   3.469446951953614e-18 ,       31.79851632221204
+    NRCB4_FULL ,         20 ,          2 ,          0 ,  -6.709581883542899e-08 ,    6.38422037163669e-08 ,     0.00215373180436267 ,  -0.0020935324940174927
+    NRCB4_FULL ,         21 ,          1 ,          1 , -2.1509448922459775e-07 ,  -9.112311025594254e-08 ,     0.00702920876108879 ,   0.0028750871441249734
+
+    Parameters
+    ----------
+    filename : str
+        Name of text file containing the data.
+
+    Returns
+    -------
+    tab : astropy.table.Table
+        Table containing distortion coefficients.
+    """
+    converters = {'siaf_index': [ascii.convert_numpy(str)]}
+    tab = ascii.read(filename, format='csv', header_start=7, data_start=8, converters=converters)
+
+    # Catch if the file format changes
+    if 'Sci2IdlX' not in tab.colnames:
+        raise ValueError("distortion_coeffs_file was not read correctly. You may need to adjust header and data starting lines.")
+
+    return tab
+
+
+def read_siaf_params_file(filename):
+    """Read the file containing V2/V3 Ref and Angle data.
+
+    Currently, this file is not used when populating a new distortion
+    reference file.
+
+    Example file:
+
+    V2Ref       = 0.028307615938974295
+    V3Ref       = 0.03990523039978199
+    V3SciXAngle = -90.2219128530577
+    V3SciYAngle = 0.03711886628887312
+
+    Parameters
+    ----------
+    filename : str
+        Name of text file containing the data.
+
+    Returns
+    -------
+    results : dict
+        Dictionary of values with parameter names for keys
+    """
+    results = {}
+
+    tab = ascii.read(filename)
+    for row in tab:
+        results[row['col1']] = row['col3']
+
+    return results
 
 
 def v2v3_model(from_sys, to_sys, par, angle):


### PR DESCRIPTION
This PR updates the distortion reference file generation code such that it can take a set of distortion coefficients from a user-provided text file, rather than retrieving them from pysiaf. The code currently assumes that the text file input has been generated by the [jwst_fpa package](https://github.com/tonysohn/jwst_fpa). 